### PR TITLE
fix mask of sensitiv data

### DIFF
--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -304,7 +304,9 @@ class SynologyDSM:
                     url, params=params, timeout=self._timeout, **kwargs
                 )
 
-            if params["api"] == API_AUTH:  # pragma: no cover
+            if all(
+                [params["api"] == API_AUTH, params.get("account"), params.get("passwd")]
+            ):  # pragma: no cover
                 self._debuglog(
                     "Request url: "
                     + response.url.replace(params["account"], "********").replace(


### PR DESCRIPTION
mask sensitiv data only, when existing in call.
this prevents key errors in case of reload of integration in HA