### PR TITLE
Workaround for 2fa bug in DSM 7.0.1-update2

### DIFF
--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -149,7 +149,6 @@ class SynologyDSM:
             # "enable_syno_token": "yes",
             "enable_device_token": "yes",
             "device_name": socket.gethostname(),
-            "format": "sid",
         }
 
         if otp_code:


### PR DESCRIPTION
based on findings in https://github.com/home-assistant/core/issues/64867#issuecomment-1075221542 the parameter `format=sid` is removed from login API call.
This has been tested with following versions to avoid regressions
- vDSM 6.2.4-update 5
- vDSM 7.0.1-update2