### PR TITLE
Fix post requests

### DIFF
--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -298,12 +298,14 @@ class SynologyDSM:
                 data = {}
                 data.update(params)
                 data.update(kwargs.pop("data", {}))
-                data["mimeType"] = "application/json"
+                if not 'headers' in kwargs:
+                    kwargs["headers"] = {}
+                kwargs["headers"]['Content-Type'] = 'application/x-www-form-urlencoded'
                 kwargs["data"] = data
                 self._debuglog("POST data: " + str(data))
 
                 response = self._session.post(
-                    url, params=params, timeout=self._timeout, **kwargs
+                    url, timeout=self._timeout, **kwargs
                 )
 
             response_url = response.url


### PR DESCRIPTION
Post requests should be sent as as x-www-form-urlencoded
They should not be using params

While most requests did no cause any issues, once I tried using a nested dictionary in post requests it became an issue