### PR TITLE
Always use base dsm host to format camera live view paths

### DIFF
--- a/src/synology_dsm/api/surveillance_station/__init__.py
+++ b/src/synology_dsm/api/surveillance_station/__init__.py
@@ -28,7 +28,9 @@ class SynoSurveillanceStation:
             if camera_data["id"] in self._cameras_by_id:
                 self._cameras_by_id[camera_data["id"]].update(camera_data)
             else:
-                self._cameras_by_id[camera_data["id"]] = SynoCamera(camera_data)
+                self._cameras_by_id[camera_data["id"]] = SynoCamera(
+                    camera_data, self._dsm._base_url
+                )
 
         for camera_id in self._cameras_by_id:
             self._cameras_by_id[camera_id].update_motion_detection(

--- a/tests/test_synology_dsm_6.py
+++ b/tests/test_synology_dsm_6.py
@@ -468,7 +468,12 @@ class TestSynologyDSM6:
         assert dsm_6.surveillance_station.get_all_cameras()
         assert dsm_6.surveillance_station.get_camera(1)
         assert dsm_6.surveillance_station.get_camera_live_view_path(1)
-        assert dsm_6.surveillance_station.get_camera_live_view_path(1, "rtsp")
+        assert dsm_6.surveillance_station.get_camera_live_view_path(1, "rtsp") == "rtsp://syno:stmkey1234567890@nas.mywebsite.me:554/Sms=1.unicast"
+        assert dsm_6.surveillance_station.get_camera_live_view_path(1, "mjpeg_http") == "http://nas.mywebsite.me:5000/webapi/entry.cgi?api=SYNO.SurveillanceStation.Stream.VideoStreaming&version=1&method=Stream&format=mjpeg&cameraId=1&StmKey=\"stmkey1234567890\""
+        assert dsm_6.surveillance_station.get_camera_live_view_path(1, "multicast") == "rtsp://syno:stmkey1234567890@nas.mywebsite.me:554/Sms=1.multicast"
+        assert dsm_6.surveillance_station.get_camera_live_view_path(1, "mxpeg_http") == "http://nas.mywebsite.me:5000/webapi/entry.cgi?api=SYNO.SurveillanceStation.Stream.VideoStreaming&version=1&method=Stream&format=mxpeg&cameraId=1&StmKey=\"stmkey1234567890\""
+        assert dsm_6.surveillance_station.get_camera_live_view_path(1, "rtsp_http") == "rtsp://nas.mywebsite.me:5000/webman/3rdparty/SurveillanceStation/cgi/rtsp.cgi?Sms=1.unicast&DsId=0&StmKey=stmkey1234567890"
+        assert dsm_6.surveillance_station.get_camera_live_view_path(1, "rtsp") == "rtsp://syno:stmkey1234567890@nas.mywebsite.me:554/Sms=1.unicast"
 
         # Motion detection
         assert dsm_6.surveillance_station.enable_motion_detection(1).get("success")


### PR DESCRIPTION
Hi @mib1185,

This PR introduces a change which should make everyone's life just a little bit easier: when setting up this module, we have to provide a hostname or IP for the Synology DSM connection. However, due to a number of reasons — such as Docker network configuration, multiple NICs being used, reverse proxies and others — the actual camera live view URL will always return the IP or host configuration that Synology believes to be more adequate.

However, think about this: we, as module _consumers_, configure the hostname or IP based on what we know about our own network setup and routing, to eventually receive back an unexpected — and potentially unreachable — URL of a camera's live view.

In my opinion, we can magically fix this by replacing whatever hostname or IP Synology Surveillance Station returns with the base URL configured in the module. It is guaranteed to succeed since connectivity has been achieved already.

My particular network configuration involves a bit of an elaborate macvlan setup inside Docker on Synology DSM, which makes the originally returned IP become unreachable due to host <> container network limitations in this network topology.

Example:

**Before**

- Configure module to connect to `nas.mywebsite.me`.
- Connection succeeds, cameras are listed.
- Obtaining a camera live view URL yields `rtsp://syno:stmkey1234567890@192.168.1.100:554/Sms=1.unicast`

**After**

- Configure module to connect to `nas.mywebsite.me`.
- Connection succeeds, cameras are listed.
- Obtaining a camera live view URL yields `rtsp://syno:stmkey1234567890@nas.mywebsite.me:554/Sms=1.unicast`