### PR TITLE
BREAKING: Rework to aiohttp

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,6 +11,15 @@
         "kind": "test",
         "isDefault": true
       }
+    },
+    {
+      "label": "reinstall dependencies",
+      "type": "shell",
+      "command": "pip3 --disable-pip-version-check --no-cache-dir install -r requirements_dev.txt",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
     }
   ]
 }

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===========================
-Python API for Synology DSM
+Asynchronous Python API for Synology DSM
 ===========================
 
 .. image:: https://github.com/mib1185/py-synologydsm-api/workflows/Tests/badge.svg
@@ -33,7 +33,7 @@ Installation
 Usage
 =====
 
-You can import the module as `synology_dsm`.
+You can import the module as ``synology_dsm``.
 
 
 Constructor
@@ -42,16 +42,18 @@ Constructor
 .. code-block:: python
 
     SynologyDSM(
+        session,
         dsm_ip,
         dsm_port,
         username,
         password,
         use_https=False,
-        verify_ssl=False,
-        timeout=None,
+        timeout=10,
         device_token=None,
         debugmode=False,
     )
+
+For ``session`` a valid ``aiohttp.ClientSession`` needs to be provided. If ssl verification should be truned off, configure the session accordingly (eq. ``aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=False)``)
 
 ``device_token`` should be added when using a two-step authentication account, otherwise DSM will ask to login with a One Time Password (OTP) and requests will fail (see the login section for more details).
 
@@ -79,188 +81,248 @@ The ``SynologyDSM`` class can also ``update()`` all APIs at once.
 
 .. code-block:: python
 
+    import asyncio
+    import aiohttp
     from synology_dsm import SynologyDSM
 
-    print("Creating Valid API")
-    api = SynologyDSM("<IP/DNS>", "<port>", "<username>", "<password>")
+    async def main():
+        print("Creating Valid API")
+        async with aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(verify_ssl=False)
+        ) as session:
+            await do(session)
 
-    print("=== Information ===")
-    api.information.update()
-    print("Model:           " + str(api.information.model))
-    print("RAM:             " + str(api.information.ram) + " MB")
-    print("Serial number:   " + str(api.information.serial))
-    print("Temperature:     " + str(api.information.temperature) + " °C")
-    print("Temp. warning:   " + str(api.information.temperature_warn))
-    print("Uptime:          " + str(api.information.uptime))
-    print("Full DSM version:" + str(api.information.version_string))
-    print("--")
-
-    print("=== Utilisation ===")
-    api.utilisation.update()
-    print("CPU Load:        " + str(api.utilisation.cpu_total_load) + " %")
-    print("Memory Use:      " + str(api.utilisation.memory_real_usage) + " %")
-    print("Net Up:          " + str(api.utilisation.network_up()))
-    print("Net Down:        " + str(api.utilisation.network_down()))
-    print("--")
-
-    print("=== Storage ===")
-    api.storage.update()
-    for volume_id in api.storage.volumes_ids:
-        print("ID:          " + str(volume_id))
-        print("Status:      " + str(api.storage.volume_status(volume_id)))
-        print("% Used:      " + str(api.storage.volume_percentage_used(volume_id)) + " %")
+    async def do(session: aiohttp.ClientSession):
+        api = SynologyDSM(session, "<IP/DNS>", "<port>", "<username>", "<password>")
+        print("=== Information ===")
+        await api.information.update()
+        print("Model:           " + str(api.information.model))
+        print("RAM:             " + str(api.information.ram) + " MB")
+        print("Serial number:   " + str(api.information.serial))
+        print("Temperature:     " + str(api.information.temperature) + " °C")
+        print("Temp. warning:   " + str(api.information.temperature_warn))
+        print("Uptime:          " + str(api.information.uptime))
+        print("Full DSM version:" + str(api.information.version_string))
         print("--")
 
-    for disk_id in api.storage.disks_ids:
-        print("ID:          " + str(disk_id))
-        print("Name:        " + str(api.storage.disk_name(disk_id)))
-        print("S-Status:    " + str(api.storage.disk_smart_status(disk_id)))
-        print("Status:      " + str(api.storage.disk_status(disk_id)))
-        print("Temp:        " + str(api.storage.disk_temp(disk_id)))
+        print("=== Utilisation ===")
+        await api.utilisation.update()
+        print("CPU Load:        " + str(api.utilisation.cpu_total_load) + " %")
+        print("Memory Use:      " + str(api.utilisation.memory_real_usage) + " %")
+        print("Net Up:          " + str(api.utilisation.network_up()))
+        print("Net Down:        " + str(api.utilisation.network_down()))
         print("--")
 
-    print("=== Shared Folders ===")
-    api.share.update()
-    for share_uuid in api.share.shares_uuids:
-        print("Share name:        " + str(api.share.share_name(share_uuid)))
-        print("Share path:        " + str(api.share.share_path(share_uuid)))
-        print("Space used:        " + str(api.share.share_size(share_uuid, human_readable=True)))
-        print("Recycle Bin Enabled: " + str(api.share.share_recycle_bin(share_uuid)))
-        print("--")
+        print("=== Storage ===")
+        await api.storage.update()
+        for volume_id in api.storage.volumes_ids:
+            print("ID:          " + str(volume_id))
+            print("Status:      " + str(api.storage.volume_status(volume_id)))
+            print("% Used:      " + str(api.storage.volume_percentage_used(volume_id)) + " %")
+            print("--")
 
+        for disk_id in api.storage.disks_ids:
+            print("ID:          " + str(disk_id))
+            print("Name:        " + str(api.storage.disk_name(disk_id)))
+            print("S-Status:    " + str(api.storage.disk_smart_status(disk_id)))
+            print("Status:      " + str(api.storage.disk_status(disk_id)))
+            print("Temp:        " + str(api.storage.disk_temp(disk_id)))
+            print("--")
+
+        print("=== Shared Folders ===")
+        await api.share.update()
+        for share_uuid in api.share.shares_uuids:
+            print("Share name:        " + str(api.share.share_name(share_uuid)))
+            print("Share path:        " + str(api.share.share_path(share_uuid)))
+            print("Space used:        " + str(api.share.share_size(share_uuid, human_readable=True)))
+            print("Recycle Bin Enabled: " + str(api.share.share_recycle_bin(share_uuid)))
+            print("--")
+
+    if __name__ == "__main__":
+        asyncio.run(main())
 
 Download Station usage
 --------------------------
 
 .. code-block:: python
 
+    import asyncio
+    import aiohttp
     from synology_dsm import SynologyDSM
 
-    api = SynologyDSM("<IP/DNS>", "<port>", "<username>", "<password>")
+    async def main():
+        print("Creating Valid API")
+        async with aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(verify_ssl=False)
+        ) as session:
+            await do(session)
 
-    if "SYNO.DownloadStation.Info" in api.apis:
+    async def do(session: aiohttp.ClientSession):
+        api = SynologyDSM(session, "<IP/DNS>", "<port>", "<username>", "<password>")
 
-        api.download_station.get_info()
-        api.download_station.get_config()
+        if "SYNO.DownloadStation.Info" in api.apis:
 
-        # The download list will be updated after each of the following functions:
-        # You should have the right on the (default) directory that the download will be saved, or you will get a 403 or 406 error
-        api.download_station.create("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
-        api.download_station.pause("dbid_1")
-        # Like the other function, you can eather pass a str or a list
-        api.download_station.resume(["dbid_1", "dbid_2"])
-        api.download_station.delete("dbid_3")
+            await api.download_station.get_info()
+            await api.download_station.get_config()
 
-        # Manual update
-        api.download_station.update()
+            # The download list will be updated after each of the following functions:
+            # You should have the right on the (default) directory that the download will be saved, or you will get a 403 or 406 error
+            await api.download_station.create("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
+            await api.download_station.pause("dbid_1")
+            # Like the other function, you can eather pass a str or a list
+            await api.download_station.resume(["dbid_1", "dbid_2"])
+            await api.download_station.delete("dbid_3")
 
+            # Manual update
+            await api.download_station.update()
+
+    if __name__ == "__main__":
+        asyncio.run(main())
 
 Surveillance Station usage
 --------------------------
 
 .. code-block:: python
 
+    import asyncio
+    import aiohttp
     from synology_dsm import SynologyDSM
 
-    api = SynologyDSM("<IP/DNS>", "<port>", "<username>", "<password>")
-    surveillance = api.surveillance_station
-    surveillance.update() # First update is required
+    async def main():
+        print("Creating Valid API")
+        async with aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(verify_ssl=False)
+        ) as session:
+            await do(session)
 
-    # Returns a list of cached cameras available
-    cameras = surveillance.get_all_cameras()
+    async def do(session: aiohttp.ClientSession):
+        api = SynologyDSM(session, "<IP/DNS>", "<port>", "<username>", "<password>")
 
-    # Assuming there's at least one camera, get the first camera_id
-    camera_id = cameras[0].camera_id
+        surveillance = api.surveillance_station
+        await surveillance.update() # First update is required
 
-    # Returns cached camera object by camera_id
-    camera = surveillance.get_camera(camera_id)
+        # Returns a list of cached cameras available
+        cameras = surveillance.get_all_cameras()
 
-    # Returns cached motion detection enabled
-    motion_setting = camera.is_motion_detection_enabled
+        # Assuming there's at least one camera, get the first camera_id
+        camera_id = cameras[0].camera_id
 
-    # Return bytes of camera image
-    surveillance.get_camera_image(camera_id)
+        # Returns cached camera object by camera_id
+        camera = surveillance.get_camera(camera_id)
 
-    # Updates all cameras/motion settings and cahce them
-    surveillance.update()
+        # Returns cached motion detection enabled
+        motion_setting = camera.is_motion_detection_enabled
 
-    # Gets Home Mode status
-    home_mode_status =  surveillance.get_home_mode_status()
+        # Return bytes of camera image
+        await surveillance.get_camera_image(camera_id)
 
-    # Sets home mode - true is on, false is off
-    surveillance.set_home_mode(True)
+        # Updates all cameras/motion settings and cahce them
+        await surveillance.update()
 
+        # Gets Home Mode status
+        home_mode_status = await surveillance.get_home_mode_status()
+
+        # Sets home mode - true is on, false is off
+        await surveillance.set_home_mode(True)
+
+    if __name__ == "__main__":
+        asyncio.run(main())
 
 System usage
 --------------------------
 
 .. code-block:: python
 
+    import asyncio
+    import aiohttp
     from synology_dsm import SynologyDSM
 
-    api = SynologyDSM("<IP/DNS>", "<port>", "<username>", "<password>")
-    system = api.system
+    async def main():
+        print("Creating Valid API")
+        async with aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(verify_ssl=False)
+        ) as session:
+            await do(session)
 
-    # Reboot NAS
-    system.reboot()
+    async def do(session: aiohttp.ClientSession):
+        api = SynologyDSM(session, "<IP/DNS>", "<port>", "<username>", "<password>")
 
-    # Shutdown NAS
-    system.shutdown()
+        system = api.system
 
-    # Manual update system information
-    system.update()
+        # Reboot NAS
+        await system.reboot()
 
-    # Get CPU information
-    system.cpu_clock_speed
-    system.cpu_cores
-    system.cpu_family
-    system.cpu_series
+        # Shutdown NAS
+        await system.shutdown()
 
-    # Get NTP settings
-    system.enabled_ntp
-    system.ntp_server
+        # Manual update system information
+        await system.update()
 
-    # Get system information
-    system.firmware_ver
-    system.model
-    system.ram_size
-    system.serial
-    system.sys_temp
-    system.time
-    system.time_zone
-    system.time_zone_desc
-    system.up_time
+        # Get CPU information
+        system.cpu_clock_speed
+        system.cpu_cores
+        system.cpu_family
+        system.cpu_series
 
-    # Get list of all connected USB devices
-    system.usb_dev
+        # Get NTP settings
+        system.enabled_ntp
+        system.ntp_server
 
+        # Get system information
+        system.firmware_ver
+        system.model
+        system.ram_size
+        system.serial
+        system.sys_temp
+        system.time
+        system.time_zone
+        system.time_zone_desc
+        system.up_time
+
+        # Get list of all connected USB devices
+        system.usb_dev
+
+    if __name__ == "__main__":
+        asyncio.run(main())
 
 Upgrade usage
 --------------------------
 
 .. code-block:: python
 
+    import asyncio
+    import aiohttp
     from synology_dsm import SynologyDSM
 
-    api = SynologyDSM("<IP/DNS>", "<port>", "<username>", "<password>")
-    upgrade = api.upgrade
+    async def main():
+        print("Creating Valid API")
+        async with aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(verify_ssl=False)
+        ) as session:
+            await do(session)
 
-    # Manual update upgrade information
-    upgrade.update()
+    async def do(session: aiohttp.ClientSession):
+        api = SynologyDSM(session, "<IP/DNS>", "<port>", "<username>", "<password>")
+        upgrade = api.upgrade
 
-    # check if DSM update is available
-    if upgrade.update_available:
-        do something ...
+        # Manual update upgrade information
+        await upgrade.update()
 
-    # get available version string (return None if no update available)
-    upgrade.available_version
+        # check if DSM update is available
+        if upgrade.update_available:
+            do something ...
 
-    # get need of reboot (return None if no update available)
-    upgrade.reboot_needed
+        # get available version string (return None if no update available)
+        upgrade.available_version
 
-    # get need of service restarts (return None if no update available)
-    upgrade.service_restarts
+        # get need of reboot (return None if no update available)
+        upgrade.reboot_needed
 
+        # get need of service restarts (return None if no update available)
+        upgrade.service_restarts
+
+    if __name__ == "__main__":
+        asyncio.run(main())
 
 Credits / Special Thanks
 ========================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 keywords=["synology-dsm", "synology"]
 requires-python = ">=3.7.0"
-dependencies  = ["requests","urllib3"]
+dependencies  = ["aiohttp", "async-timeout"]
 
 [project.urls]
 Changelog = "https://github.com/mib1185/py-synologydsm-api/releases"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,23 +1,24 @@
 -r requirements.txt
 
-pytest==7.2.0
-coverage[toml]
-safety==2.2.1
-mypy==0.931
-typeguard==2.12.1
-pre-commit==2.14.0
-flake8==5.0.4
 black==22.8.0
+coverage[toml]
+darglint==1.8.1
 flake8-bandit==4.1.1
 flake8-bugbear==22.10.27
 flake8-docstrings==1.6.0
 flake8-rst-docstrings==0.2.7
+flake8==5.0.4
+mypy==0.931
 pep8-naming==0.12.1
-darglint==1.8.1
-reorder-python-imports==3.8.2
 pre-commit-hooks==3.4.0
-sphinx-rtd-theme==1.0.0
+pre-commit==2.14.0
 Pygments==2.8.1
 pylint==2.15.6
+pytest-asyncio==0.20.3
+pytest==7.2.0
+reorder-python-imports==3.8.2
+safety==2.2.1
+sphinx-rtd-theme==1.0.0
+typeguard==2.12.1
 
 -e .

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,6 @@
 
 black==22.8.0
 coverage[toml]
-darglint==1.8.1
 flake8-bandit==4.1.1
 flake8-bugbear==22.10.27
 flake8-docstrings==1.6.0
@@ -17,8 +16,5 @@ pylint==2.15.6
 pytest-asyncio==0.20.3
 pytest==7.2.0
 reorder-python-imports==3.8.2
-safety==2.2.1
-sphinx-rtd-theme==1.0.0
-typeguard==2.12.1
 
 -e .

--- a/src/synology_dsm/api/core/security.py
+++ b/src/synology_dsm/api/core/security.py
@@ -7,9 +7,9 @@ class SynoCoreSecurity(SynoBaseApi):
 
     API_KEY = "SYNO.Core.SecurityScan.Status"
 
-    def update(self):
+    async def update(self):
         """Updates security data."""
-        raw_data = self._dsm.get(self.API_KEY, "system_get")
+        raw_data = await self._dsm.get(self.API_KEY, "system_get")
         if raw_data:
             self._data = raw_data["data"]
 

--- a/src/synology_dsm/api/core/share.py
+++ b/src/synology_dsm/api/core/share.py
@@ -21,9 +21,9 @@ class SynoCoreShare(SynoBaseApi):
         "shareType": "all",
     }
 
-    def update(self):
+    async def update(self):
         """Updates share data."""
-        raw_data = self._dsm.post(self.API_KEY, "list", data=self.REQUEST_DATA)
+        raw_data = await self._dsm.post(self.API_KEY, "list", data=self.REQUEST_DATA)
         if raw_data:
             self._data = raw_data["data"]
 

--- a/src/synology_dsm/api/core/system.py
+++ b/src/synology_dsm/api/core/system.py
@@ -7,9 +7,9 @@ class SynoCoreSystem(SynoBaseApi):
 
     API_KEY = "SYNO.Core.System"
 
-    def update(self):
+    async def update(self):
         """Updates System data."""
-        raw_data = self._dsm.get(self.API_KEY, "info")
+        raw_data = await self._dsm.get(self.API_KEY, "info")
         if raw_data:
             self._data = raw_data["data"]
 
@@ -99,20 +99,18 @@ class SynoCoreSystem(SynoBaseApi):
     #
     # do system actions
     #
-    def shutdown(self):
+    async def shutdown(self):
         """Shutdown NAS."""
-        res = self._dsm.get(
+        return await self._dsm.get(
             self.API_KEY,
             "shutdown",
             max_version=1,  # shutdown method is only available on api version 1
         )
-        return res
 
-    def reboot(self):
+    async def reboot(self):
         """Reboot NAS."""
-        res = self._dsm.get(
+        return await self._dsm.get(
             self.API_KEY,
             "reboot",
             max_version=1,  # reboot method is only available on api version 1
         )
-        return res

--- a/src/synology_dsm/api/core/upgrade.py
+++ b/src/synology_dsm/api/core/upgrade.py
@@ -8,9 +8,9 @@ class SynoCoreUpgrade(SynoBaseApi):
     API_KEY = "SYNO.Core.Upgrade"
     API_SERVER_KEY = API_KEY + ".Server"
 
-    def update(self):
+    async def update(self):
         """Updates Upgrade data."""
-        raw_data = self._dsm.get(self.API_SERVER_KEY, "check")
+        raw_data = await self._dsm.get(self.API_SERVER_KEY, "check")
         if raw_data:
             self._data = raw_data["data"].get("update", raw_data["data"])
 

--- a/src/synology_dsm/api/core/utilization.py
+++ b/src/synology_dsm/api/core/utilization.py
@@ -8,9 +8,9 @@ class SynoCoreUtilization(SynoBaseApi):
 
     API_KEY = "SYNO.Core.System.Utilization"
 
-    def update(self):
+    async def update(self):
         """Updates utilization data."""
-        raw_data = self._dsm.get(self.API_KEY, "get")
+        raw_data = await self._dsm.get(self.API_KEY, "get")
         if raw_data:
             self._data = raw_data["data"]
 

--- a/src/synology_dsm/api/download_station/__init__.py
+++ b/src/synology_dsm/api/download_station/__init__.py
@@ -15,10 +15,11 @@ class SynoDownloadStation(SynoBaseApi):
         "additional": "detail,file"
     }  # Can contain: detail, transfer, file, tracker, peer
 
-    def update(self):
+    async def update(self):
         """Update tasks from API."""
         self._data = {}
-        list_data = self._dsm.get(self.TASK_API_KEY, "List", self.REQUEST_DATA)["data"]
+        raw_data = await self._dsm.get(self.TASK_API_KEY, "List", self.REQUEST_DATA)
+        list_data = raw_data["data"]
         for task_data in list_data["tasks"]:
             if task_data["id"] in self._data:
                 self._data[task_data["id"]].update(task_data)
@@ -26,17 +27,17 @@ class SynoDownloadStation(SynoBaseApi):
                 self._data[task_data["id"]] = SynoDownloadTask(task_data)
 
     # Global
-    def get_info(self):
+    async def get_info(self):
         """Return general informations about the Download Station instance."""
-        return self._dsm.get(self.INFO_API_KEY, "GetInfo")
+        return await self._dsm.get(self.INFO_API_KEY, "GetInfo")
 
-    def get_config(self):
+    async def get_config(self):
         """Return configuration about the Download Station instance."""
-        return self._dsm.get(self.INFO_API_KEY, "GetConfig")
+        return await self._dsm.get(self.INFO_API_KEY, "GetConfig")
 
-    def get_stat(self):
+    async def get_stat(self):
         """Return statistic about the Download Station instance."""
-        return self._dsm.get(self.STAT_API_KEY, "GetInfo")
+        return await self._dsm.get(self.STAT_API_KEY, "GetInfo")
 
     # Downloads
     def get_all_tasks(self):
@@ -61,29 +62,29 @@ class SynoDownloadStation(SynoBaseApi):
         self.update()
         return res
 
-    def pause(self, task_id):
+    async def pause(self, task_id):
         """Pause a download task."""
-        res = self._dsm.get(
+        res = await self._dsm.get(
             self.TASK_API_KEY,
             "Pause",
             {"id": ",".join(task_id) if isinstance(task_id, list) else task_id},
         )
-        self.update()
+        await self.update()
         return res
 
-    def resume(self, task_id):
+    async def resume(self, task_id):
         """Resume a paused download task."""
-        res = self._dsm.get(
+        res = await self._dsm.get(
             self.TASK_API_KEY,
             "Resume",
             {"id": ",".join(task_id) if isinstance(task_id, list) else task_id},
         )
-        self.update()
+        await self.update()
         return res
 
-    def delete(self, task_id, force_complete=False):
+    async def delete(self, task_id, force_complete=False):
         """Delete a download task."""
-        res = self._dsm.get(
+        res = await self._dsm.get(
             self.TASK_API_KEY,
             "Delete",
             {
@@ -91,5 +92,5 @@ class SynoDownloadStation(SynoBaseApi):
                 "force_complete": force_complete,
             },
         )
-        self.update()
+        await self.update()
         return res

--- a/src/synology_dsm/api/dsm/information.py
+++ b/src/synology_dsm/api/dsm/information.py
@@ -7,11 +7,11 @@ class SynoDSMInformation(SynoBaseApi):
 
     API_KEY = "SYNO.DSM.Info"
 
-    def update(self):
+    async def update(self):
         """Updates information data."""
-        raw_data = self._dsm.get(self.API_KEY, "getinfo")
+        raw_data = await self._dsm.get(self.API_KEY, "getinfo")
         if raw_data:
-            self._data = raw_data["data"]
+            self._data: dict = raw_data["data"]
 
     @property
     def model(self):

--- a/src/synology_dsm/api/dsm/network.py
+++ b/src/synology_dsm/api/dsm/network.py
@@ -7,9 +7,9 @@ class SynoDSMNetwork(SynoBaseApi):
 
     API_KEY = "SYNO.DSM.Network"
 
-    def update(self):
+    async def update(self):
         """Updates network data."""
-        raw_data = self._dsm.get(self.API_KEY, "list")
+        raw_data = await self._dsm.get(self.API_KEY, "list")
         if raw_data:
             self._data = raw_data["data"]
 

--- a/src/synology_dsm/api/storage/storage.py
+++ b/src/synology_dsm/api/storage/storage.py
@@ -8,9 +8,9 @@ class SynoStorage(SynoBaseApi):
 
     API_KEY = "SYNO.Storage.CGI.Storage"
 
-    def update(self):
+    async def update(self):
         """Updates storage data."""
-        raw_data = self._dsm.get(self.API_KEY, "load_info")
+        raw_data = await self._dsm.get(self.API_KEY, "load_info")
         if raw_data:
             self._data = raw_data
             if raw_data.get("data"):

--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -4,8 +4,8 @@ import socket
 from json import JSONDecodeError
 from urllib.parse import quote
 
-import urllib3
-from requests import Session
+import aiohttp
+import async_timeout
 from requests.exceptions import RequestException
 
 from .api.core.security import SynoCoreSecurity
@@ -44,12 +44,12 @@ class SynologyDSM:
 
     def __init__(
         self,
+        session: aiohttp.ClientSession,
         dsm_ip: str,
         dsm_port: int,
         username: str,
         password: str,
         use_https: bool = False,
-        verify_ssl: bool = False,
         timeout: int = None,
         device_token: str = None,
         debugmode: bool = False,
@@ -59,11 +59,9 @@ class SynologyDSM:
         self._password = password
         self._timeout = timeout or 10
         self._debugmode = debugmode
-        self._verify = verify_ssl & use_https
 
         # Session
-        self._session = Session()
-        self._session.verify = self._verify
+        self._session = session
 
         # Login
         self._session_id = None
@@ -87,10 +85,6 @@ class SynologyDSM:
 
         # Build variables
         if use_https:
-            if not verify_ssl:
-                # disable SSL warnings due to the auto-genenerated cert
-                urllib3.disable_warnings()
-
             self._base_url = f"https://{dsm_ip}:{dsm_port}"
         else:
             self._base_url = f"http://{dsm_ip}:{dsm_port}"
@@ -124,23 +118,24 @@ class SynologyDSM:
 
         return f"{self._base_url}/webapi/{self.apis[api]['path']}?"
 
-    def discover_apis(self):
+    async def discover_apis(self):
         """Retreives available API infos from the NAS."""
         if self._apis.get(API_AUTH):
             return
-        self._apis = self.get(API_INFO, "query")["data"]
+        data = await self.get(API_INFO, "query")
+        self._apis = data["data"]
 
     @property
     def apis(self):
         """Gets available API infos from the NAS."""
         return self._apis
 
-    def login(self, otp_code: str = None) -> bool:
+    async def login(self, otp_code: str = None) -> bool:
         """Create a logged session."""
         # First reset the session
         self._debuglog("Creating new session")
-        self._session = Session()
-        self._session.verify = self._verify
+        # self._session = Session()
+        # self._session.verify = self._verify
 
         params = {
             "account": self.username,
@@ -156,7 +151,7 @@ class SynologyDSM:
             params["device_id"] = self._device_token
 
         # Request login
-        result = self.get(API_AUTH, "login", params)
+        result = await self.get(API_AUTH, "login", params)
 
         # Handle errors
         if result.get("error"):
@@ -193,10 +188,10 @@ class SynologyDSM:
 
         return result["success"]
 
-    def logout(self) -> bool:
+    async def logout(self) -> bool:
         """Log out of the session."""
-        result = self.get(API_AUTH, "logout")
-        self._session = None
+        result = await self.get(API_AUTH, "logout")
+        # self._session = None
         return result["success"]
 
     @property
@@ -207,15 +202,15 @@ class SynologyDSM:
         """
         return self._device_token
 
-    def get(self, api: str, method: str, params: dict = None, **kwargs):
+    async def get(self, api: str, method: str, params: dict = None, **kwargs):
         """Handles API GET request."""
-        return self._request("GET", api, method, params, **kwargs)
+        return await self._request("GET", api, method, params, **kwargs)
 
-    def post(self, api: str, method: str, params: dict = None, **kwargs):
+    async def post(self, api: str, method: str, params: dict = None, **kwargs):
         """Handles API POST request."""
-        return self._request("POST", api, method, params, **kwargs)
+        return await self._request("POST", api, method, params, **kwargs)
 
-    def _request(
+    async def _request(
         self,
         request_method: str,
         api: str,
@@ -227,11 +222,11 @@ class SynologyDSM:
         """Handles API request."""
         # Discover existing APIs
         if api != API_INFO:
-            self.discover_apis()
+            await self.discover_apis()
 
         # Check if logged
         if not self._session_id and api not in [API_AUTH, API_INFO]:
-            self.login()
+            await self.login()
 
         # Build request params
         if not params:
@@ -262,7 +257,7 @@ class SynologyDSM:
         # Request data
         self._debuglog("API: " + api)
         self._debuglog("Request Method: " + request_method)
-        response = self._execute_request(request_method, url, params, **kwargs)
+        response = await self._execute_request(request_method, url, params, **kwargs)
         self._debuglog("Successful returned data")
         self._debuglog("RESPONSE: " + str(response))
 
@@ -282,7 +277,7 @@ class SynologyDSM:
 
         return response
 
-    def _execute_request(self, method: str, url: str, params: dict, **kwargs):
+    async def _execute_request(self, method: str, url: str, params: dict, **kwargs):
         """Function to execute and handle a request."""
         # Execute Request
         try:
@@ -290,9 +285,10 @@ class SynologyDSM:
                 encoded_params = "&".join(
                     f"{key}={quote(str(value))}" for key, value in params.items()
                 )
-                response = self._session.get(
-                    url, params=encoded_params, timeout=self._timeout, **kwargs
-                )
+                async with async_timeout.timeout(self._timeout):
+                    response = await self._session.get(
+                        url, params=encoded_params, timeout=self._timeout, **kwargs
+                    )
             elif method == "POST":
                 data = {}
                 data.update(params)
@@ -301,21 +297,22 @@ class SynologyDSM:
                 kwargs["data"] = data
                 self._debuglog("POST data: " + str(data))
 
-                response = self._session.post(
-                    url, params=params, timeout=self._timeout, **kwargs
-                )
+                async with async_timeout.timeout(self._timeout):
+                    response = await self._session.post(
+                        url, params=params, timeout=self._timeout, **kwargs
+                    )
 
-            response_url = response.url
+            response_url = str(response.url)
             for param in SENSITIV_PARAMS:
                 if params.get(param):
                     response_url = response_url.replace(
                         quote(params[param]), "********"
                     )
             self._debuglog("Request url: " + response_url)
-            self._debuglog("Response status_code: " + str(response.status_code))
-            self._debuglog("Response headers: " + str(response.headers))
+            self._debuglog("Response status_code: " + str(response.status))
+            self._debuglog("Response headers: " + str(dict(response.headers)))
 
-            if response.status_code == 200:
+            if response.status == 200:
                 # We got a DSM response
                 content_type = response.headers.get("Content-Type", "").split(";")[0]
 
@@ -324,9 +321,9 @@ class SynologyDSM:
                     "text/json",
                     "text/plain",  # Can happen with some API
                 ]:
-                    return response.json()
+                    return await response.json()
 
-                return response.content
+                return await response.text()
 
             # We got a 400, 401 or 404 ...
             raise RequestException(response)

--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -50,14 +50,14 @@ class SynologyDSM:
         username: str,
         password: str,
         use_https: bool = False,
-        timeout: int = None,
+        timeout: int = 10,
         device_token: str = None,
         debugmode: bool = False,
     ):
         """Constructor method."""
         self.username = username
         self._password = password
-        self._timeout = timeout or 10
+        self._timeout = timeout
         self._debugmode = debugmode
 
         # Session
@@ -284,7 +284,7 @@ class SynologyDSM:
                 )
                 async with async_timeout.timeout(self._timeout):
                     response = await self._session.get(
-                        url, params=encoded_params, timeout=self._timeout, **kwargs
+                        url, params=encoded_params, **kwargs
                     )
             elif method == "POST":
                 data = {}
@@ -295,9 +295,7 @@ class SynologyDSM:
                 self._debuglog("POST data: " + str(data))
 
                 async with async_timeout.timeout(self._timeout):
-                    response = await self._session.post(
-                        url, params=params, timeout=self._timeout, **kwargs
-                    )
+                    response = await self._session.post(url, params=params, **kwargs)
 
             response_url = str(response.url)
             for param in SENSITIV_PARAMS:

--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -134,8 +134,6 @@ class SynologyDSM:
         """Create a logged session."""
         # First reset the session
         self._debuglog("Creating new session")
-        # self._session = Session()
-        # self._session.verify = self._verify
 
         params = {
             "account": self.username,
@@ -191,7 +189,6 @@ class SynologyDSM:
     async def logout(self) -> bool:
         """Log out of the session."""
         result = await self.get(API_AUTH, "logout")
-        # self._session = None
         return result["success"]
 
     @property
@@ -328,7 +325,7 @@ class SynologyDSM:
             # We got a 400, 401 or 404 ...
             raise RequestException(response)
 
-        except (RequestException, JSONDecodeError) as exp:
+        except (aiohttp.ClientError, JSONDecodeError) as exp:
             raise SynologyDSMRequestException(exp) from exp
 
     async def update(self, with_information: bool = False, with_network: bool = False):

--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -184,7 +184,7 @@ class SynologyDSM:
 
         if not self._information:
             self._information = SynoDSMInformation(self)
-            self._information.update()
+            await self._information.update()
 
         return result["success"]
 
@@ -331,37 +331,37 @@ class SynologyDSM:
         except (RequestException, JSONDecodeError) as exp:
             raise SynologyDSMRequestException(exp) from exp
 
-    def update(self, with_information: bool = False, with_network: bool = False):
+    async def update(self, with_information: bool = False, with_network: bool = False):
         """Updates the various instanced modules."""
         if self._download:
-            self._download.update()
+            await self._download.update()
 
         if self._information and with_information:
-            self._information.update()
+            await self._information.update()
 
         if self._network and with_network:
-            self._network.update()
+            await self._network.update()
 
         if self._security:
-            self._security.update()
+            await self._security.update()
 
         if self._utilisation:
-            self._utilisation.update()
+            await self._utilisation.update()
 
         if self._storage:
-            self._storage.update()
+            await self._storage.update()
 
         if self._share:
-            self._share.update()
+            await self._share.update()
 
         if self._surveillance:
-            self._surveillance.update()
+            await self._surveillance.update()
 
         if self._system:
-            self._system.update()
+            await self._system.update()
 
         if self._upgrade:
-            self._upgrade.update()
+            await self._upgrade.update()
 
     def reset(self, api: any) -> bool:
         """Reset an API to avoid fetching in on update."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -143,7 +143,7 @@ class SynologyDSMMock(SynologyDSM):
         username,
         password,
         use_https=False,
-        timeout=None,
+        timeout=10,
         device_token=None,
         debugmode=False,
     ):
@@ -166,7 +166,7 @@ class SynologyDSMMock(SynologyDSM):
         self.error = False
         self.with_surveillance = False
 
-    def _execute_request(self, method, url, params, **kwargs):
+    async def _execute_request(self, method, url, params, **kwargs):
         url += urlencode(params or {})
 
         if "no_internet" in url:
@@ -201,11 +201,6 @@ class SynologyDSMMock(SynologyDSM):
 
         if "https" not in url:
             raise SynologyDSMRequestException(RequestException("Bad request"))
-
-        # if not self.verify_ssl:
-        #     raise SynologyDSMRequestException(
-        #         SSLError(f"hostname '192.168.0.35' doesn't match '{VALID_HOST}'")
-        #     )
 
         if API_INFO in url:
             if self.with_surveillance:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -137,12 +137,12 @@ class SynologyDSMMock(SynologyDSM):
 
     def __init__(
         self,
+        session,
         dsm_ip,
         dsm_port,
         username,
         password,
         use_https=False,
-        verify_ssl=False,
         timeout=None,
         device_token=None,
         debugmode=False,
@@ -150,18 +150,17 @@ class SynologyDSMMock(SynologyDSM):
         """Constructor method."""
         SynologyDSM.__init__(
             self,
+            session,
             dsm_ip,
             dsm_port,
             username,
             password,
             use_https,
-            verify_ssl,
             timeout,
             device_token,
             debugmode,
         )
 
-        self.verify_ssl = verify_ssl
         self.dsm_version = 6  # 5 or 6
         self.disks_redundancy = "RAID"  # RAID or SHR[number][_EXPANSION]
         self.error = False
@@ -203,10 +202,10 @@ class SynologyDSMMock(SynologyDSM):
         if "https" not in url:
             raise SynologyDSMRequestException(RequestException("Bad request"))
 
-        if not self.verify_ssl:
-            raise SynologyDSMRequestException(
-                SSLError(f"hostname '192.168.0.35' doesn't match '{VALID_HOST}'")
-            )
+        # if not self.verify_ssl:
+        #     raise SynologyDSMRequestException(
+        #         SSLError(f"hostname '192.168.0.35' doesn't match '{VALID_HOST}'")
+        #     )
 
         if API_INFO in url:
             if self.with_surveillance:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from . import (
     VALID_PASSWORD,
     VALID_PORT,
     VALID_USER,
-    VALID_VERIFY_SSL,
     SynologyDSMMock,
 )
 
@@ -18,12 +17,12 @@ from . import (
 def api() -> SynologyDSM:
     """Return a mock DSM 6 API."""
     return SynologyDSMMock(
+        None,
         VALID_HOST,
         VALID_PORT,
         VALID_USER,
         VALID_PASSWORD,
         VALID_HTTPS,
-        VALID_VERIFY_SSL,
     )
 
 

--- a/tests/test_synology_dsm.py
+++ b/tests/test_synology_dsm.py
@@ -29,7 +29,6 @@ from . import (
     VALID_PORT,
     VALID_USER,
     VALID_USER_2SA,
-    VALID_VERIFY_SSL,
     SynologyDSMMock,
 )
 
@@ -46,20 +45,21 @@ class TestSynologyDSM:
         assert not dsm._session_id
 
     @pytest.mark.parametrize("version", [5, 6, 7])
-    def test_login_basic_failed(self, version):
+    @pytest.mark.asyncio
+    async def test_login_basic_failed(self, version):
         """Test basic failed login."""
         dsm = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             USER_MAX_TRY,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
         )
         dsm.dsm_version = version
 
         with pytest.raises(SynologyDSMLoginFailedException) as error:
-            dsm.login()
+            await dsm.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 407
@@ -67,20 +67,21 @@ class TestSynologyDSM:
         assert error_value["details"] == USER_MAX_TRY
 
     @pytest.mark.parametrize("version", [5, 6, 7])
-    def test_login_2sa_failed(self, version):
+    @pytest.mark.asyncio
+    async def test_login_2sa_failed(self, version):
         """Test failed login with 2SA."""
         dsm = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
         )
         dsm.dsm_version = version
 
         with pytest.raises(SynologyDSMLogin2SARequiredException) as error:
-            dsm.login()
+            await dsm.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 403
@@ -91,7 +92,7 @@ class TestSynologyDSM:
         )
 
         with pytest.raises(SynologyDSMLogin2SAFailedException) as error:
-            dsm.login(888888)
+            await dsm.login(888888)
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 404
@@ -106,20 +107,21 @@ class TestSynologyDSM:
         assert dsm._device_token is None
 
     @pytest.mark.parametrize("version", [5, 6, 7])
-    def test_connection_failed(self, version):
+    @pytest.mark.asyncio
+    async def test_connection_failed(self, version):
         """Test failed connection."""
         # No internet
         dsm = SynologyDSMMock(
+            None,
             "no_internet",
             VALID_PORT,
             VALID_USER,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
         )
         dsm.dsm_version = version
         with pytest.raises(SynologyDSMRequestException) as error:
-            dsm.login()
+            await dsm.login()
         error_value = error.value.args[0]
         assert not error_value["api"]
         assert error_value["code"] == -1
@@ -134,16 +136,16 @@ class TestSynologyDSM:
 
         # Wrong host
         dsm = SynologyDSMMock(
+            None,
             "host",
             VALID_PORT,
             VALID_USER,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
         )
         dsm.dsm_version = version
         with pytest.raises(SynologyDSMRequestException) as error:
-            dsm.login()
+            await dsm.login()
         error_value = error.value.args[0]
         assert not error_value["api"]
         assert error_value["code"] == -1
@@ -158,11 +160,16 @@ class TestSynologyDSM:
 
         # Wrong port
         dsm = SynologyDSMMock(
-            VALID_HOST, 0, VALID_USER, VALID_PASSWORD, VALID_HTTPS, VALID_VERIFY_SSL
+            None,
+            VALID_HOST,
+            0,
+            VALID_USER,
+            VALID_PASSWORD,
+            VALID_HTTPS,
         )
         dsm.dsm_version = version
         with pytest.raises(SynologyDSMRequestException) as error:
-            dsm.login()
+            await dsm.login()
         error_value = error.value.args[0]
         assert not error_value["api"]
         assert error_value["code"] == -1
@@ -177,16 +184,16 @@ class TestSynologyDSM:
 
         # Wrong HTTPS
         dsm = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER,
             VALID_PASSWORD,
             False,
-            VALID_VERIFY_SSL,
         )
         dsm.dsm_version = version
         with pytest.raises(SynologyDSMRequestException) as error:
-            dsm.login()
+            await dsm.login()
         error_value = error.value.args[0]
         assert not error_value["api"]
         assert error_value["code"] == -1
@@ -198,16 +205,16 @@ class TestSynologyDSM:
 
         # Wrong SSL
         dsm = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER,
             VALID_PASSWORD,
             VALID_HTTPS,
-            False,
         )
         dsm.dsm_version = version
         with pytest.raises(SynologyDSMRequestException) as error:
-            dsm.login()
+            await dsm.login()
         error_value = error.value.args[0]
         assert not error_value["api"]
         assert error_value["code"] == -1
@@ -221,19 +228,20 @@ class TestSynologyDSM:
         assert not dsm._session_id
 
     @pytest.mark.parametrize("version", [5, 6, 7])
-    def test_login_failed(self, version):
+    @pytest.mark.asyncio
+    async def test_login_failed(self, version):
         """Test failed login."""
         dsm = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             "user",
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
         )
         dsm.dsm_version = version
         with pytest.raises(SynologyDSMLoginInvalidException) as error:
-            dsm.login()
+            await dsm.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 400
@@ -244,16 +252,16 @@ class TestSynologyDSM:
         assert not dsm._session_id
 
         dsm = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER,
             "pass",
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
         )
         dsm.dsm_version = version
         with pytest.raises(SynologyDSMLoginInvalidException) as error:
-            dsm.login()
+            await dsm.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 400
@@ -270,28 +278,30 @@ class TestSynologyDSM:
     def test_request_timeout(self, version):
         """Test request timeout."""
         dsm = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
             timeout=2,
         )
         dsm.dsm_version = version
         assert dsm._timeout == 2
 
-    def test_request_get(self, dsm):
+    @pytest.mark.asyncio
+    async def test_request_get(self, dsm):
         """Test get request."""
-        assert dsm.get(API_INFO, "query")
-        assert dsm.get(API_AUTH, "login")
-        assert dsm.get("SYNO.DownloadStation2.Task", "list")
-        assert dsm.get(API_AUTH, "logout")
+        assert await dsm.get(API_INFO, "query")
+        assert await dsm.get(API_AUTH, "login")
+        assert await dsm.get("SYNO.DownloadStation2.Task", "list")
+        assert await dsm.get(API_AUTH, "logout")
 
-    def test_request_get_failed(self, dsm):
+    @pytest.mark.asyncio
+    async def test_request_get_failed(self, dsm):
         """Test failed get request."""
         with pytest.raises(SynologyDSMAPINotExistsException) as error:
-            dsm.get("SYNO.Virtualization.API.Task.Info", "list")
+            await dsm.get("SYNO.Virtualization.API.Task.Info", "list")
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.Virtualization.API.Task.Info"
         assert error_value["code"] == -2
@@ -301,16 +311,17 @@ class TestSynologyDSM:
             == "API SYNO.Virtualization.API.Task.Info does not exists"
         )
 
-    def test_request_post(self, dsm):
+    @pytest.mark.asyncio
+    async def test_request_post(self, dsm):
         """Test post request."""
-        assert dsm.post(
+        assert await dsm.post(
             "SYNO.FileStation.Upload",
             "upload",
             params={"dest_folder_path": "/upload/test", "create_parents": True},
             files={"file": "open('file.txt','rb')"},
         )
 
-        assert dsm.post(
+        assert await dsm.post(
             "SYNO.DownloadStation2.Task",
             "create",
             params={
@@ -320,10 +331,11 @@ class TestSynologyDSM:
             },
         )
 
-    def test_request_post_failed(self, dsm):
+    @pytest.mark.asyncio
+    async def test_request_post_failed(self, dsm):
         """Test failed post request."""
         with pytest.raises(SynologyDSMAPIErrorException) as error:
-            dsm.post(
+            await dsm.post(
                 "SYNO.FileStation.Upload",
                 "upload",
                 params={"dest_folder_path": "/upload/test", "create_parents": True},
@@ -339,7 +351,7 @@ class TestSynologyDSM:
         assert not error_value["details"]
 
         with pytest.raises(SynologyDSMAPIErrorException) as error:
-            dsm.post(
+            await dsm.post(
                 "SYNO.DownloadStation2.Task",
                 "create",
                 params={
@@ -528,14 +540,16 @@ class TestSynologyDSM:
         assert not dsm.reset(dsm.information)
         assert dsm._information
 
-    def test_utilisation(self, dsm):
+    @pytest.mark.asyncio
+    async def test_utilisation(self, dsm):
         """Test utilisation."""
         assert dsm.utilisation
-        dsm.utilisation.update()
+        await dsm.utilisation.update()
 
-    def test_utilisation_cpu(self, dsm):
+    @pytest.mark.asyncio
+    async def test_utilisation_cpu(self, dsm):
         """Test utilisation CPU."""
-        dsm.utilisation.update()
+        await dsm.utilisation.update()
         assert dsm.utilisation.cpu
         assert dsm.utilisation.cpu_other_load
         assert dsm.utilisation.cpu_user_load
@@ -545,11 +559,12 @@ class TestSynologyDSM:
         assert dsm.utilisation.cpu_5min_load
         assert dsm.utilisation.cpu_15min_load
 
-    def test_utilisation_error(self, dsm):
+    @pytest.mark.asyncio
+    async def test_utilisation_error(self, dsm):
         """Test utilisation error."""
         dsm.error = True
         with pytest.raises(SynologyDSMAPIErrorException) as error:
-            dsm.utilisation.update()
+            await dsm.utilisation.update()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.Core.System.Utilization"
         assert error_value["code"] == 1055
@@ -561,9 +576,10 @@ class TestSynologyDSM:
             "err_session": "",
         }
 
-    def test_utilisation_memory(self, dsm):
+    @pytest.mark.asyncio
+    async def test_utilisation_memory(self, dsm):
         """Test utilisation memory."""
-        dsm.utilisation.update()
+        await dsm.utilisation.update()
         assert dsm.utilisation.memory
         assert dsm.utilisation.memory_real_usage
         assert dsm.utilisation.memory_size()
@@ -579,9 +595,10 @@ class TestSynologyDSM:
         assert dsm.utilisation.memory_total_swap()
         assert dsm.utilisation.memory_total_swap(True)
 
-    def test_utilisation_network(self, dsm):
+    @pytest.mark.asyncio
+    async def test_utilisation_network(self, dsm):
         """Test utilisation network."""
-        dsm.utilisation.update()
+        await dsm.utilisation.update()
         assert dsm.utilisation.network
         assert dsm.utilisation.network_up()
         assert dsm.utilisation.network_up(True)

--- a/tests/test_synology_dsm.py
+++ b/tests/test_synology_dsm.py
@@ -38,8 +38,8 @@ class TestSynologyDSM:
 
     def test_init(self, dsm):
         """Test init."""
-        assert dsm.username
-        assert dsm._base_url
+        assert dsm.username == VALID_USER
+        assert dsm._base_url == f"https://{VALID_HOST}:{VALID_PORT}"
         assert dsm._timeout == 10
         assert not dsm.apis.get(API_AUTH)
         assert not dsm._session_id
@@ -199,30 +199,6 @@ class TestSynologyDSM:
         assert error_value["code"] == -1
         assert error_value["reason"] == "Unknown"
         assert error_value["details"] == "RequestException = Bad request"
-
-        assert not dsm.apis.get(API_AUTH)
-        assert not dsm._session_id
-
-        # Wrong SSL
-        dsm = SynologyDSMMock(
-            None,
-            VALID_HOST,
-            VALID_PORT,
-            VALID_USER,
-            VALID_PASSWORD,
-            VALID_HTTPS,
-        )
-        dsm.dsm_version = version
-        with pytest.raises(SynologyDSMRequestException) as error:
-            await dsm.login()
-        error_value = error.value.args[0]
-        assert not error_value["api"]
-        assert error_value["code"] == -1
-        assert error_value["reason"] == "Unknown"
-        assert (
-            error_value["details"]
-            == f"SSLError = hostname '192.168.0.35' doesn't match '{VALID_HOST}'"
-        )
 
         assert not dsm.apis.get(API_AUTH)
         assert not dsm._session_id

--- a/tests/test_synology_dsm_5.py
+++ b/tests/test_synology_dsm_5.py
@@ -11,7 +11,6 @@ from . import (
     VALID_PASSWORD,
     VALID_PORT,
     VALID_USER_2SA,
-    VALID_VERIFY_SSL,
     SynologyDSMMock,
 )
 from .const import DEVICE_TOKEN, SESSION_ID
@@ -20,56 +19,60 @@ from .const import DEVICE_TOKEN, SESSION_ID
 class TestSynologyDSM5:
     """SynologyDSM 5test cases."""
 
-    def test_login(self, dsm_5):
+    @pytest.mark.asyncio
+    async def test_login(self, dsm_5):
         """Test login."""
-        assert dsm_5.login()
+        assert await dsm_5.login()
         assert dsm_5.apis.get(API_AUTH)
         assert dsm_5._session_id == SESSION_ID
         assert dsm_5._syno_token is None
 
-    def test_login_2sa(self):
+    @pytest.mark.asyncio
+    async def test_login_2sa(self):
         """Test login with 2SA."""
         dsm_5 = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
         )
         dsm_5.dsm_version = 5
         with pytest.raises(SynologyDSMLogin2SARequiredException):
-            dsm_5.login()
-        dsm_5.login(VALID_OTP)
+            await dsm_5.login()
+        await dsm_5.login(VALID_OTP)
 
         assert dsm_5._session_id == SESSION_ID
         assert dsm_5._syno_token is None
         assert dsm_5._device_token == DEVICE_TOKEN
         assert dsm_5.device_token == DEVICE_TOKEN
 
-    def test_login_2sa_new_session(self):
+    @pytest.mark.asyncio
+    async def test_login_2sa_new_session(self):
         """Test login with 2SA and a new session with granted device."""
         dsm_5 = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
             device_token=DEVICE_TOKEN,
         )
         dsm_5.dsm_version = 5
-        assert dsm_5.login()
+        assert await dsm_5.login()
 
         assert dsm_5._session_id == SESSION_ID
         assert dsm_5._syno_token is None
         assert dsm_5._device_token == DEVICE_TOKEN
         assert dsm_5.device_token == DEVICE_TOKEN
 
-    def test_information(self, dsm_5):
+    @pytest.mark.asyncio
+    async def test_information(self, dsm_5):
         """Test information."""
         assert dsm_5.information
-        dsm_5.information.update()
+        await dsm_5.information.update()
         assert dsm_5.information.model == "DS3615xs"
         assert dsm_5.information.ram == 6144
         assert dsm_5.information.serial == "B3J4N01003"
@@ -79,10 +82,11 @@ class TestSynologyDSM5:
         assert dsm_5.information.version == "5967"
         assert dsm_5.information.version_string == "DSM 5.2-5967 Update 9"
 
-    def test_network(self, dsm_5):
+    @pytest.mark.asyncio
+    async def test_network(self, dsm_5):
         """Test network."""
         assert dsm_5.network
-        dsm_5.network.update()
+        await dsm_5.network.update()
         assert dsm_5.network.dns
         assert dsm_5.network.gateway
         assert dsm_5.network.hostname
@@ -92,18 +96,20 @@ class TestSynologyDSM5:
         assert dsm_5.network.macs
         assert dsm_5.network.workgroup
 
-    def test_storage(self, dsm_5):
+    @pytest.mark.asyncio
+    async def test_storage(self, dsm_5):
         """Test storage roots."""
         assert dsm_5.storage
-        dsm_5.storage.update()
+        await dsm_5.storage.update()
         assert dsm_5.storage.disks
         assert dsm_5.storage.env
         assert dsm_5.storage.storage_pools == []
         assert dsm_5.storage.volumes
 
-    def test_storage_volumes(self, dsm_5):
+    @pytest.mark.asyncio
+    async def test_storage_volumes(self, dsm_5):
         """Test storage volumes."""
-        dsm_5.storage.update()
+        await dsm_5.storage.update()
         # Basics
         assert dsm_5.storage.volumes_ids
         for volume_id in dsm_5.storage.volumes_ids:
@@ -160,9 +166,10 @@ class TestSynologyDSM5:
         assert dsm_5.storage.volume_disk_temp_avg("test_volume") is None
         assert dsm_5.storage.volume_disk_temp_max("test_volume") is None
 
-    def test_storage_disks(self, dsm_5):
+    @pytest.mark.asyncio
+    async def test_storage_disks(self, dsm_5):
         """Test storage disks."""
-        dsm_5.storage.update()
+        await dsm_5.storage.update()
         # Basics
         assert dsm_5.storage.disks_ids
         for disk_id in dsm_5.storage.disks_ids:

--- a/tests/test_synology_dsm_6.py
+++ b/tests/test_synology_dsm_6.py
@@ -11,7 +11,6 @@ from . import (
     VALID_PASSWORD,
     VALID_PORT,
     VALID_USER_2SA,
-    VALID_VERIFY_SSL,
     SynologyDSMMock,
 )
 from .const import DEVICE_TOKEN, SESSION_ID, SYNO_TOKEN
@@ -20,26 +19,28 @@ from .const import DEVICE_TOKEN, SESSION_ID, SYNO_TOKEN
 class TestSynologyDSM6:
     """SynologyDSM 6 test cases."""
 
-    def test_login(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_login(self, dsm_6):
         """Test login."""
-        assert dsm_6.login()
+        assert await dsm_6.login()
         assert dsm_6.apis.get(API_AUTH)
         assert dsm_6._session_id == SESSION_ID
         assert dsm_6._syno_token == SYNO_TOKEN
 
-    def test_login_2sa(self):
+    @pytest.mark.asyncio
+    async def test_login_2sa(self):
         """Test login with 2SA."""
         dsm = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
         )
 
         with pytest.raises(SynologyDSMLogin2SARequiredException) as error:
-            dsm.login()
+            await dsm.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 403
@@ -49,35 +50,37 @@ class TestSynologyDSM6:
             == "Two-step authentication required for account: valid_user_2sa"
         )
 
-        assert dsm.login(VALID_OTP)
+        assert await dsm.login(VALID_OTP)
 
         assert dsm._session_id == SESSION_ID
         assert dsm._syno_token == SYNO_TOKEN
         assert dsm._device_token == DEVICE_TOKEN
         assert dsm.device_token == DEVICE_TOKEN
 
-    def test_login_2sa_new_session(self):
+    @pytest.mark.asyncio
+    async def test_login_2sa_new_session(self):
         """Test login with 2SA and a new session with granted device."""
         dsm = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
             device_token=DEVICE_TOKEN,
         )
-        assert dsm.login()
+        assert await dsm.login()
 
         assert dsm._session_id == SESSION_ID
         assert dsm._syno_token == SYNO_TOKEN
         assert dsm._device_token == DEVICE_TOKEN
         assert dsm.device_token == DEVICE_TOKEN
 
-    def test_information(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_information(self, dsm_6):
         """Test information."""
         assert dsm_6.information
-        dsm_6.information.update()
+        await dsm_6.information.update()
         assert dsm_6.information.model == "DS918+"
         assert dsm_6.information.ram == 4096
         assert dsm_6.information.serial == "1920PDN001501"
@@ -87,10 +90,11 @@ class TestSynologyDSM6:
         assert dsm_6.information.version == "24922"
         assert dsm_6.information.version_string == "DSM 6.2.2-24922 Update 4"
 
-    def test_network(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_network(self, dsm_6):
         """Test network."""
         assert dsm_6.network
-        dsm_6.network.update()
+        await dsm_6.network.update()
         assert dsm_6.network.dns
         assert dsm_6.network.gateway
         assert dsm_6.network.hostname
@@ -100,10 +104,11 @@ class TestSynologyDSM6:
         assert dsm_6.network.macs
         assert dsm_6.network.workgroup
 
-    def test_security(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_security(self, dsm_6):
         """Test security, safe status."""
         assert dsm_6.security
-        dsm_6.security.update()
+        await dsm_6.security.update()
         assert dsm_6.security.checks
         assert dsm_6.security.last_scan_time
         assert not dsm_6.security.start_time  # Finished scan
@@ -118,11 +123,12 @@ class TestSynologyDSM6:
         assert dsm_6.security.status_by_check["update"] == "safe"
         assert dsm_6.security.status_by_check["userInfo"] == "safe"
 
-    def test_security_error(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_security_error(self, dsm_6):
         """Test security, outOfDate status."""
         dsm_6.error = True
         assert dsm_6.security
-        dsm_6.security.update()
+        await dsm_6.security.update()
         assert dsm_6.security.checks
         assert dsm_6.security.last_scan_time
         assert not dsm_6.security.start_time  # Finished scan
@@ -137,10 +143,11 @@ class TestSynologyDSM6:
         assert dsm_6.security.status_by_check["update"] == "outOfDate"
         assert dsm_6.security.status_by_check["userInfo"] == "safe"
 
-    def test_shares(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_shares(self, dsm_6):
         """Test shares."""
         assert dsm_6.share
-        dsm_6.share.update()
+        await dsm_6.share.update()
         assert dsm_6.share.shares
         for share_uuid in dsm_6.share.shares_uuids:
             assert dsm_6.share.share_name(share_uuid)
@@ -169,10 +176,11 @@ class TestSynologyDSM6:
             == "32.9Eb"
         )
 
-    def test_system(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_system(self, dsm_6):
         """Test system."""
         assert dsm_6.system
-        dsm_6.system.update()
+        await dsm_6.system.update()
         assert dsm_6.system.cpu_clock_speed
         assert dsm_6.system.cpu_cores
         assert dsm_6.system.cpu_family
@@ -194,10 +202,11 @@ class TestSynologyDSM6:
             assert usb_dev.get("rev")
             assert usb_dev.get("vid")
 
-    def test_upgrade(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_upgrade(self, dsm_6):
         """Test upgrade."""
         assert dsm_6.upgrade
-        dsm_6.upgrade.update()
+        await dsm_6.upgrade.update()
         assert dsm_6.upgrade.update_available
         assert dsm_6.upgrade.available_version == "DSM 6.2.3-25426 Update 2"
         assert dsm_6.upgrade.reboot_needed == "now"
@@ -211,18 +220,20 @@ class TestSynologyDSM6:
             "os_name": "DSM",
         }
 
-    def test_storage(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_storage(self, dsm_6):
         """Test storage roots."""
         assert dsm_6.storage
-        dsm_6.storage.update()
+        await dsm_6.storage.update()
         assert dsm_6.storage.disks
         assert dsm_6.storage.env
         assert dsm_6.storage.storage_pools
         assert dsm_6.storage.volumes
 
-    def test_storage_raid_volumes(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_storage_raid_volumes(self, dsm_6):
         """Test RAID storage volumes."""
-        dsm_6.storage.update()
+        await dsm_6.storage.update()
         # Basics
         assert dsm_6.storage.volumes_ids
         for volume_id in dsm_6.storage.volumes_ids:
@@ -271,10 +282,11 @@ class TestSynologyDSM6:
         assert dsm_6.storage.volume_disk_temp_avg("test_volume") is None
         assert dsm_6.storage.volume_disk_temp_max("test_volume") is None
 
-    def test_storage_shr_volumes(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_storage_shr_volumes(self, dsm_6):
         """Test SHR storage volumes."""
         dsm_6.disks_redundancy = "SHR1"
-        dsm_6.storage.update()
+        await dsm_6.storage.update()
 
         # Basics
         assert dsm_6.storage.volumes_ids
@@ -338,10 +350,11 @@ class TestSynologyDSM6:
         assert dsm_6.storage.volume_disk_temp_avg("test_volume") is None
         assert dsm_6.storage.volume_disk_temp_max("test_volume") is None
 
-    def test_storage_shr2_volumes(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_storage_shr2_volumes(self, dsm_6):
         """Test SHR2 storage volumes."""
         dsm_6.disks_redundancy = "SHR2"
-        dsm_6.storage.update()
+        await dsm_6.storage.update()
 
         # Basics
         assert dsm_6.storage.volumes_ids
@@ -367,10 +380,11 @@ class TestSynologyDSM6:
         assert dsm_6.storage.volume_disk_temp_avg("volume_1") == 37.0
         assert dsm_6.storage.volume_disk_temp_max("volume_1") == 41
 
-    def test_storage_shr2_expansion_volumes(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_storage_shr2_expansion_volumes(self, dsm_6):
         """Test SHR2 storage with expansion unit volumes."""
         dsm_6.disks_redundancy = "SHR2_EXPANSION"
-        dsm_6.storage.update()
+        await dsm_6.storage.update()
 
         # Basics
         assert dsm_6.storage.volumes_ids
@@ -396,9 +410,10 @@ class TestSynologyDSM6:
         assert dsm_6.storage.volume_disk_temp_avg("volume_1") == 33.0
         assert dsm_6.storage.volume_disk_temp_max("volume_1") == 35
 
-    def test_storage_disks(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_storage_disks(self, dsm_6):
         """Test storage disks."""
-        dsm_6.storage.update()
+        await dsm_6.storage.update()
         # Basics
         assert dsm_6.storage.disks_ids
         for disk_id in dsm_6.storage.disks_ids:
@@ -430,7 +445,8 @@ class TestSynologyDSM6:
         assert dsm_6.storage.disk_below_remain_life_thr("test_disk") is None
         assert dsm_6.storage.disk_temp("test_disk") is None
 
-    def test_download_station(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_download_station(self, dsm_6):
         """Test DownloadStation."""
         assert dsm_6.download_station
         assert not dsm_6.download_station.get_all_tasks()
@@ -438,7 +454,7 @@ class TestSynologyDSM6:
         assert dsm_6.download_station.get_info()["data"]["version"]
         assert dsm_6.download_station.get_config()["data"]["default_destination"]
         assert dsm_6.download_station.get_stat()["data"]["speed_download"]
-        dsm_6.download_station.update()
+        await dsm_6.download_station.update()
         assert dsm_6.download_station.get_all_tasks()
         assert len(dsm_6.download_station.get_all_tasks()) == 8
 
@@ -459,13 +475,14 @@ class TestSynologyDSM6:
         )
         assert dsm_6.download_station.get_task("dbid_549").type == "https"
 
-    def test_surveillance_station(self, dsm_6):
+    @pytest.mark.asyncio
+    async def test_surveillance_station(self, dsm_6):
         """Test SurveillanceStation."""
         dsm_6.with_surveillance = True
         assert dsm_6.surveillance_station
         assert not dsm_6.surveillance_station.get_all_cameras()
 
-        dsm_6.surveillance_station.update()
+        await dsm_6.surveillance_station.update()
         assert dsm_6.surveillance_station.get_all_cameras()
         assert dsm_6.surveillance_station.get_camera(1)
         assert dsm_6.surveillance_station.get_camera_live_view_path(1)

--- a/tests/test_synology_dsm_6.py
+++ b/tests/test_synology_dsm_6.py
@@ -451,9 +451,11 @@ class TestSynologyDSM6:
         assert dsm_6.download_station
         assert not dsm_6.download_station.get_all_tasks()
 
-        assert dsm_6.download_station.get_info()["data"]["version"]
-        assert dsm_6.download_station.get_config()["data"]["default_destination"]
-        assert dsm_6.download_station.get_stat()["data"]["speed_download"]
+        assert (await dsm_6.download_station.get_info())["data"]["version"]
+        assert (await dsm_6.download_station.get_config())["data"][
+            "default_destination"
+        ]
+        assert (await dsm_6.download_station.get_stat())["data"]["speed_download"]
         await dsm_6.download_station.update()
         assert dsm_6.download_station.get_all_tasks()
         assert len(dsm_6.download_station.get_all_tasks()) == 8
@@ -489,10 +491,14 @@ class TestSynologyDSM6:
         assert dsm_6.surveillance_station.get_camera_live_view_path(1, "rtsp")
 
         # Motion detection
-        assert dsm_6.surveillance_station.enable_motion_detection(1).get("success")
-        assert dsm_6.surveillance_station.disable_motion_detection(1).get("success")
+        assert (await dsm_6.surveillance_station.enable_motion_detection(1)).get(
+            "success"
+        )
+        assert (await dsm_6.surveillance_station.disable_motion_detection(1)).get(
+            "success"
+        )
 
         # Home mode
-        assert dsm_6.surveillance_station.get_home_mode_status()
-        assert dsm_6.surveillance_station.set_home_mode(False)
-        assert dsm_6.surveillance_station.set_home_mode(True)
+        assert await dsm_6.surveillance_station.get_home_mode_status()
+        assert await dsm_6.surveillance_station.set_home_mode(False)
+        assert await dsm_6.surveillance_station.set_home_mode(True)

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -11,7 +11,6 @@ from . import (
     VALID_PASSWORD,
     VALID_PORT,
     VALID_USER_2SA,
-    VALID_VERIFY_SSL,
     SynologyDSMMock,
 )
 from .const import DEVICE_TOKEN, SESSION_ID, SYNO_TOKEN
@@ -20,26 +19,28 @@ from .const import DEVICE_TOKEN, SESSION_ID, SYNO_TOKEN
 class TestSynologyDSM7:
     """SynologyDSM 7 test cases."""
 
-    def test_login(self, dsm_7):
+    @pytest.mark.asyncio
+    async def test_login(self, dsm_7):
         """Test login."""
-        assert dsm_7.login()
+        assert await dsm_7.login()
         assert dsm_7.apis.get(API_AUTH)
         assert dsm_7._session_id == SESSION_ID
         assert dsm_7._syno_token == SYNO_TOKEN
 
-    def test_login_2sa(self):
+    @pytest.mark.asyncio
+    async def test_login_2sa(self):
         """Test login with 2SA."""
         dsm_7 = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
         )
         dsm_7.dsm_version = 7
         with pytest.raises(SynologyDSMLogin2SARequiredException) as error:
-            dsm_7.login()
+            await dsm_7.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 403
@@ -49,36 +50,38 @@ class TestSynologyDSM7:
             == "Two-step authentication required for account: valid_user_2sa"
         )
 
-        assert dsm_7.login(VALID_OTP)
+        assert await dsm_7.login(VALID_OTP)
 
         assert dsm_7._session_id == SESSION_ID
         assert dsm_7._syno_token == SYNO_TOKEN
         assert dsm_7._device_token == DEVICE_TOKEN
         assert dsm_7.device_token == DEVICE_TOKEN
 
-    def test_login_2sa_new_session(self):
+    @pytest.mark.asyncio
+    async def test_login_2sa_new_session(self):
         """Test login with 2SA and a new session with granted device."""
         dsm_7 = SynologyDSMMock(
+            None,
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
             VALID_PASSWORD,
             VALID_HTTPS,
-            VALID_VERIFY_SSL,
             device_token=DEVICE_TOKEN,
         )
         dsm_7.dsm_version = 7
-        assert dsm_7.login()
+        assert await dsm_7.login()
 
         assert dsm_7._session_id == SESSION_ID
         assert dsm_7._syno_token == SYNO_TOKEN
         assert dsm_7._device_token == DEVICE_TOKEN
         assert dsm_7.device_token == DEVICE_TOKEN
 
-    def test_upgrade(self, dsm_7):
+    @pytest.mark.asyncio
+    async def test_upgrade(self, dsm_7):
         """Test upgrade."""
         assert dsm_7.upgrade
-        dsm_7.upgrade.update()
+        await dsm_7.upgrade.update()
         assert dsm_7.upgrade.update_available
         assert dsm_7.upgrade.available_version == "7.0.1-42218 Update 3"
         assert dsm_7.upgrade.reboot_needed == "now"


### PR DESCRIPTION
This is considered as breaking change, because it now requests an `aiohttp.ClientSession` as `session` parameter within the `SynologyDSM` constructor, but `verify_ssl` is gone. If SSL verification should be disabled, configure the session accordingly (_eq. `aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=False)`_)

Example:
```python
import asyncio
import aiohttp
from synology_dsm import SynologyDSM

async def main():
    print("Creating Valid API")
    async with aiohttp.ClientSession(
        connector=aiohttp.TCPConnector(verify_ssl=False)
    ) as session:
        api = SynologyDSM(session, "<IP/DNS>", "<port>", "<username>", "<password>")

        print("=== Information ===")
        await api.information.update()
        print("Model:           " + str(api.information.model))
        print("RAM:             " + str(api.information.ram) + " MB")
        print("Serial number:   " + str(api.information.serial))
        print("Temperature:     " + str(api.information.temperature) + " °C")
        print("Temp. warning:   " + str(api.information.temperature_warn))
        print("Uptime:          " + str(api.information.uptime))
        print("Full DSM version:" + str(api.information.version_string))
        print("--")

if __name__ == "__main__":
    asyncio.run(main())

```

---

- fixes #75
