### PR TITLE
Fix download shared photos

### DIFF
--- a/src/synology_dsm/api/photos/__init__.py
+++ b/src/synology_dsm/api/photos/__init__.py
@@ -70,7 +70,7 @@ class SynoPhotos(SynoBaseApi):
                     item["filesize"],
                     item["additional"]["thumbnail"]["cache_key"],
                     size,
-                    item["owner_user_id"],
+                    item["owner_user_id"] == 0,
                 )
             )
         return items
@@ -109,17 +109,18 @@ class SynoPhotos(SynoBaseApi):
                     item["filesize"],
                     item["additional"]["thumbnail"]["cache_key"],
                     size,
-                    item["owner_user_id"],
+                    item["owner_user_id"] == 0,
                 )
             )
         return items
 
     async def download_item(self, item: SynoPhotosItem) -> bytes | None:
         """Download the given item."""
+        download_api = self.DOWNLOAD_API_KEY
+        if item.is_shared:
+            download_api = self.DOWNLOAD_FOTOTEAM_API_KEY
         raw_data = await self._dsm.get(
-            self.DOWNLOAD_FOTOTEAM_API_KEY
-            if item.owner_user_id == 0
-            else self.DOWNLOAD_API_KEY,
+            download_api,
             "download",
             {
                 "unit_id": f"[{item.item_id}]",
@@ -132,10 +133,11 @@ class SynoPhotos(SynoBaseApi):
 
     async def download_item_thumbnail(self, item: SynoPhotosItem) -> bytes | None:
         """Download the given items thumbnail."""
+        download_api = self.THUMBNAIL_API_KEY
+        if item.is_shared:
+            download_api = self.THUMBNAIL_FOTOTEAM_API_KEY
         raw_data = await self._dsm.get(
-            self.THUMBNAIL_FOTOTEAM_API_KEY
-            if item.owner_user_id == 0
-            else self.THUMBNAIL_API_KEY,
+            download_api,
             "get",
             {
                 "id": item.item_id,
@@ -150,10 +152,11 @@ class SynoPhotos(SynoBaseApi):
 
     async def get_item_thumbnail_url(self, item: SynoPhotosItem) -> str:
         """Get the url of given items thumbnail."""
+        download_api = self.THUMBNAIL_API_KEY
+        if item.is_shared:
+            download_api = self.THUMBNAIL_FOTOTEAM_API_KEY
         return await self._dsm.generate_url(
-            self.THUMBNAIL_FOTOTEAM_API_KEY
-            if item.owner_user_id == 0
-            else self.THUMBNAIL_API_KEY,
+            download_api,
             "get",
             {
                 "id": item.item_id,

--- a/src/synology_dsm/api/photos/__init__.py
+++ b/src/synology_dsm/api/photos/__init__.py
@@ -109,6 +109,7 @@ class SynoPhotos(SynoBaseApi):
                     item["filesize"],
                     item["additional"]["thumbnail"]["cache_key"],
                     size,
+                    item["owner_user_id"],
                 )
             )
         return items

--- a/src/synology_dsm/api/photos/__init__.py
+++ b/src/synology_dsm/api/photos/__init__.py
@@ -70,6 +70,7 @@ class SynoPhotos(SynoBaseApi):
                     item["filesize"],
                     item["additional"]["thumbnail"]["cache_key"],
                     size,
+                    item["owner_user_id"],
                 )
             )
         return items

--- a/src/synology_dsm/api/photos/__init__.py
+++ b/src/synology_dsm/api/photos/__init__.py
@@ -115,7 +115,9 @@ class SynoPhotos(SynoBaseApi):
     async def download_item(self, item: SynoPhotosItem) -> bytes | None:
         """Download the given item."""
         raw_data = await self._dsm.get(
-            self.DOWNLOAD_FOTOTEAM_API_KEY if item.owner_user_id == 0 else self.DOWNLOAD_API_KEY,
+            self.DOWNLOAD_FOTOTEAM_API_KEY
+            if item.owner_user_id == 0
+            else self.DOWNLOAD_API_KEY,
             "download",
             {
                 "unit_id": f"[{item.item_id}]",
@@ -129,7 +131,9 @@ class SynoPhotos(SynoBaseApi):
     async def download_item_thumbnail(self, item: SynoPhotosItem) -> bytes | None:
         """Download the given items thumbnail."""
         raw_data = await self._dsm.get(
-            self.THUMBNAIL_FOTOTEAM_API_KEY if item.owner_user_id == 0 else self.THUMBNAIL_API_KEY,
+            self.THUMBNAIL_FOTOTEAM_API_KEY
+            if item.owner_user_id == 0
+            else self.THUMBNAIL_API_KEY,
             "get",
             {
                 "id": item.item_id,
@@ -145,7 +149,9 @@ class SynoPhotos(SynoBaseApi):
     async def get_item_thumbnail_url(self, item: SynoPhotosItem) -> str:
         """Get the url of given items thumbnail."""
         return await self._dsm.generate_url(
-            self.THUMBNAIL_FOTOTEAM_API_KEY if item.owner_user_id == 0 else self.THUMBNAIL_API_KEY,
+            self.THUMBNAIL_FOTOTEAM_API_KEY
+            if item.owner_user_id == 0
+            else self.THUMBNAIL_API_KEY,
             "get",
             {
                 "id": item.item_id,

--- a/src/synology_dsm/api/photos/__init__.py
+++ b/src/synology_dsm/api/photos/__init__.py
@@ -14,8 +14,10 @@ class SynoPhotos(SynoBaseApi):
     BROWSE_ALBUMS_API_KEY = "SYNO.Foto.Browse.Album"
     BROWSE_ITEM_API_KEY = "SYNO.Foto.Browse.Item"
     DOWNLOAD_API_KEY = "SYNO.Foto.Download"
+    DOWNLOAD_FOTOTEAM_API_KEY = "SYNO.FotoTeam.Download"
     SEARCH_API_KEY = "SYNO.Foto.Search.Search"
     THUMBNAIL_API_KEY = "SYNO.Foto.Thumbnail"
+    THUMBNAIL_FOTOTEAM_API_KEY = "SYNO.FotoTeam.Thumbnail"
 
     async def get_albums(
         self, offset: int = 0, limit: int = 100
@@ -113,7 +115,7 @@ class SynoPhotos(SynoBaseApi):
     async def download_item(self, item: SynoPhotosItem) -> bytes | None:
         """Download the given item."""
         raw_data = await self._dsm.get(
-            self.DOWNLOAD_API_KEY,
+            self.DOWNLOAD_FOTOTEAM_API_KEY if item.owner_user_id == 0 else self.DOWNLOAD_API_KEY,
             "download",
             {
                 "unit_id": f"[{item.item_id}]",
@@ -127,7 +129,7 @@ class SynoPhotos(SynoBaseApi):
     async def download_item_thumbnail(self, item: SynoPhotosItem) -> bytes | None:
         """Download the given items thumbnail."""
         raw_data = await self._dsm.get(
-            self.THUMBNAIL_API_KEY,
+            self.THUMBNAIL_FOTOTEAM_API_KEY if item.owner_user_id == 0 else self.THUMBNAIL_API_KEY,
             "get",
             {
                 "id": item.item_id,
@@ -143,7 +145,7 @@ class SynoPhotos(SynoBaseApi):
     async def get_item_thumbnail_url(self, item: SynoPhotosItem) -> str:
         """Get the url of given items thumbnail."""
         return await self._dsm.generate_url(
-            self.THUMBNAIL_API_KEY,
+            self.THUMBNAIL_FOTOTEAM_API_KEY if item.owner_user_id == 0 else self.THUMBNAIL_API_KEY,
             "get",
             {
                 "id": item.item_id,

--- a/src/synology_dsm/api/photos/model.py
+++ b/src/synology_dsm/api/photos/model.py
@@ -21,4 +21,4 @@ class SynoPhotosItem:
     file_size: str
     thumbnail_cache_key: str
     thumbnail_size: str
-    owner_user_id: int
+    is_shared: bool

--- a/src/synology_dsm/api/photos/model.py
+++ b/src/synology_dsm/api/photos/model.py
@@ -21,3 +21,4 @@ class SynoPhotosItem:
     file_size: str
     thumbnail_cache_key: str
     thumbnail_size: str
+    owner_user_id: int

--- a/tests/api_data/dsm_7/const_7_api_info.py
+++ b/tests/api_data/dsm_7/const_7_api_info.py
@@ -2914,6 +2914,18 @@ DSM_7_API_INFO = {
             "path": "entry.cgi",
             "requestFormat": "JSON",
         },
+        "SYNO.FotoTeam.Download": {
+            "maxVersion": 1,
+            "minVersion": 1,
+            "path": "entry.cgi",
+            "requestFormat": "JSON",
+        },
+        "SYNO.FotoTeam.Thumbnail": {
+            "maxVersion": 2,
+            "minVersion": 1,
+            "path": "entry.cgi",
+            "requestFormat": "JSON",
+        },
         "SYNO.License.HA": {
             "maxVersion": 1,
             "minVersion": 1,

--- a/tests/api_data/dsm_7/photos/const_7_photo.py
+++ b/tests/api_data/dsm_7/photos/const_7_photo.py
@@ -73,7 +73,7 @@ DSM_7_FOTO_ITEMS = {
                 "filesize": 2644859,
                 "time": 1668538602,
                 "indexed_time": 1668564550862,
-                "owner_user_id": 1,
+                "owner_user_id": 0,
                 "folder_id": 597,
                 "type": "photo",
                 "additional": {

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -215,3 +215,12 @@ class TestSynologyDSM7:
         assert items[0].thumbnail_cache_key == "12340_1668560967"
         assert items[1].file_name == "search_2.jpg"
         assert items[1].thumbnail_cache_key == "12341_1668560967"
+
+        thumb_url = await dsm_7.photos.get_item_thumbnail_url(items[1])
+        assert thumb_url
+        assert thumb_url == (
+            "https://nas.mywebsite.me:443/webapi/entry.cgi?"
+            "id=29808&cache_key=29808_1668560967&size=xl&type=unit"
+            "&api=SYNO.FotoTeam.Thumbnail&version=2&method=get"
+            "&_sid=session_id&SynoToken=Sy%C3%B10_T0k%E2%82%AC%C3%B1"
+        )

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -208,14 +208,6 @@ class TestSynologyDSM7:
             "&_sid=session_id&SynoToken=Sy%C3%B10_T0k%E2%82%AC%C3%B1"
         )
 
-        items = await dsm_7.photos.get_items_from_search(albums[0])
-        assert items
-        assert len(items) == 2
-        assert items[0].file_name == "search_1.jpg"
-        assert items[0].thumbnail_cache_key == "12340_1668560967"
-        assert items[1].file_name == "search_2.jpg"
-        assert items[1].thumbnail_cache_key == "12341_1668560967"
-
         thumb_url = await dsm_7.photos.get_item_thumbnail_url(items[1])
         assert thumb_url
         assert thumb_url == (
@@ -224,3 +216,13 @@ class TestSynologyDSM7:
             "&api=SYNO.FotoTeam.Thumbnail&version=2&method=get"
             "&_sid=session_id&SynoToken=Sy%C3%B10_T0k%E2%82%AC%C3%B1"
         )
+
+        items = await dsm_7.photos.get_items_from_search(albums[0])
+        assert items
+        assert len(items) == 2
+        assert items[0].file_name == "search_1.jpg"
+        assert items[0].thumbnail_cache_key == "12340_1668560967"
+        assert items[1].file_name == "search_2.jpg"
+        assert items[1].thumbnail_cache_key == "12341_1668560967"
+
+        

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -212,7 +212,7 @@ class TestSynologyDSM7:
         assert thumb_url
         assert thumb_url == (
             "https://nas.mywebsite.me:443/webapi/entry.cgi?"
-            "id=29808&cache_key=29808_1668560967&size=xl&type=unit"
+            "id=29808&cache_key=29808_1668560967&size=m&type=unit"
             "&api=SYNO.FotoTeam.Thumbnail&version=2&method=get"
             "&_sid=session_id&SynoToken=Sy%C3%B10_T0k%E2%82%AC%C3%B1"
         )

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -223,6 +223,4 @@ class TestSynologyDSM7:
         assert items[0].file_name == "search_1.jpg"
         assert items[0].thumbnail_cache_key == "12340_1668560967"
         assert items[1].file_name == "search_2.jpg"
-        assert items[1].thumbnail_cache_key == "12341_1668560967"
-
-        
+        assert items[1].thumbnail_cache_key == "12341_1668560967"        

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -223,4 +223,4 @@ class TestSynologyDSM7:
         assert items[0].file_name == "search_1.jpg"
         assert items[0].thumbnail_cache_key == "12340_1668560967"
         assert items[1].file_name == "search_2.jpg"
-        assert items[1].thumbnail_cache_key == "12341_1668560967"        
+        assert items[1].thumbnail_cache_key == "12341_1668560967"


### PR DESCRIPTION
Fix download shared photos: https://github.com/mib1185/py-synologydsm-api/issues/262

Shared photos need to be downloaded with FotoTeams api instead of Foto api