### PR TITLE
Switch to using aiohttp built-in timeouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 keywords=["synology-dsm", "synology"]
 requires-python = ">=3.8.0"
-dependencies  = ["aiohttp", "async-timeout"]
+dependencies  = ["aiohttp"]
 
 [project.urls]
 Changelog = "https://github.com/mib1185/py-synologydsm-api/releases"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,4 @@
 aiohttp
-async-timeout
 black==23.1.0
 coverage[toml]
 flake8-bandit==4.1.1

--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -73,7 +73,6 @@ class SynologyDSM:
         """Constructor method."""
         self.username = username
         self._password = password
-        self._timeout = timeout
         self._aiohttp_timeout = aiohttp.ClientTimeout(total=timeout)
         self._debugmode = debugmode
 

--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -10,7 +10,6 @@ from typing import Any, TypedDict
 from urllib.parse import quote, urlencode
 
 import aiohttp
-import async_timeout
 from yarl import URL
 
 from .api import SynoBaseApi
@@ -75,6 +74,7 @@ class SynologyDSM:
         self.username = username
         self._password = password
         self._timeout = timeout
+        self._aiohttp_timeout = aiohttp.ClientTimeout(total=timeout)
         self._debugmode = debugmode
 
         # Session
@@ -348,8 +348,9 @@ class SynologyDSM:
 
         try:
             if method == "GET":
-                async with async_timeout.timeout(self._timeout):
-                    response = await self._session.get(url_encoded, **kwargs)
+                response = await self._session.get(
+                    url_encoded, timeout=self._aiohttp_timeout, **kwargs
+                )
             elif method == "POST":
                 data = {}
                 if params is not None:
@@ -359,8 +360,9 @@ class SynologyDSM:
                 kwargs["data"] = data
                 self._debuglog("POST data: " + str(data))
 
-                async with async_timeout.timeout(self._timeout):
-                    response = await self._session.post(url_encoded, **kwargs)
+                response = await self._session.post(
+                    url_encoded, timeout=self._aiohttp_timeout, **kwargs
+                )
 
             # mask sesitiv parameters
             response_url = response.url

--- a/tests/test_synology_dsm.py
+++ b/tests/test_synology_dsm.py
@@ -44,7 +44,7 @@ class TestSynologyDSM:
         """Test init."""
         assert dsm.username == VALID_USER
         assert dsm._base_url == f"https://{VALID_HOST}:{VALID_PORT}"
-        assert dsm._timeout == 10
+        assert dsm._aiohttp_timeout.total == 10
         assert not dsm.apis.get(API_AUTH)
         assert not dsm._session_id
 
@@ -289,7 +289,7 @@ class TestSynologyDSM:
             timeout=2,
         )
         dsm.dsm_version = version
-        assert dsm._timeout == 2
+        assert dsm._aiohttp_timeout.total == 2
 
     @pytest.mark.asyncio
     async def test_request_get(self, dsm):


### PR DESCRIPTION
Drops `async_timeout` and let aiohttp handle the timeout