### PR TITLE
Fix downloading shared photos from shared album

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,6 +10,6 @@ max-line-length = 80
 max-complexity = 10
 docstring-convention = google
 per-file-ignores =
-    tests/*:S101
+    tests/*:S101,S105
     tests/**/const_*.py:B950
     src/synology_dsm/const.py:B950

--- a/src/synology_dsm/api/photos/__init__.py
+++ b/src/synology_dsm/api/photos/__init__.py
@@ -39,7 +39,7 @@ class SynoPhotos(SynoBaseApi):
                     album["id"],
                     album["name"],
                     album["item_count"],
-                    album["passphrase"] if album["passphrase"] != "" else None,
+                    album["passphrase"] if album["passphrase"] else None,
                 )
             )
         return albums
@@ -83,7 +83,7 @@ class SynoPhotos(SynoBaseApi):
             "limit": limit,
             "additional": '["thumbnail"]',
         }
-        if album.passphrase is not None:
+        if album.passphrase:
             params["passphrase"] = album.passphrase
         else:
             params["album_id"] = album.album_id
@@ -137,7 +137,7 @@ class SynoPhotos(SynoBaseApi):
             "cache_key": item.thumbnail_cache_key,
         }
 
-        if item.passphrase is not None:
+        if item.passphrase:
             params["passphrase"] = item.passphrase
 
         raw_data = await self._dsm.get(
@@ -162,7 +162,7 @@ class SynoPhotos(SynoBaseApi):
             "type": "unit",
         }
 
-        if item.passphrase is not None:
+        if item.passphrase:
             params["passphrase"] = item.passphrase
 
         raw_data = await self._dsm.get(
@@ -187,7 +187,7 @@ class SynoPhotos(SynoBaseApi):
             "type": "unit",
         }
 
-        if item.passphrase is not None:
+        if item.passphrase:
             params["passphrase"] = item.passphrase
 
         return await self._dsm.generate_url(

--- a/src/synology_dsm/api/photos/__init__.py
+++ b/src/synology_dsm/api/photos/__init__.py
@@ -26,18 +26,21 @@ class SynoPhotos(SynoBaseApi):
         """Get a list of all albums."""
         albums: list[SynoPhotosAlbum] = []
         raw_data = await self._dsm.get(
-            self.BROWSE_ALBUMS_API_KEY, "list", {
-                "offset": offset,
-                "limit": limit,
-                "category": "normal_share_with_me"
-            }
+            self.BROWSE_ALBUMS_API_KEY,
+            "list",
+            {"offset": offset, "limit": limit, "category": "normal_share_with_me"},
         )
         if not isinstance(raw_data, dict) or (data := raw_data.get("data")) is None:
             return None
 
         for album in data["list"]:
             albums.append(
-                SynoPhotosAlbum(album["id"], album["name"], album["item_count"], album["passphrase"] if album["passphrase"] != '' else None)
+                SynoPhotosAlbum(
+                    album["id"],
+                    album["name"],
+                    album["item_count"],
+                    album["passphrase"] if album["passphrase"] != "" else None,
+                )
             )
         return albums
 
@@ -134,7 +137,7 @@ class SynoPhotos(SynoBaseApi):
             "cache_key": item.thumbnail_cache_key,
         }
 
-        if item.passphrase is not None :
+        if item.passphrase is not None:
             params["passphrase"] = item.passphrase
 
         raw_data = await self._dsm.get(
@@ -159,7 +162,7 @@ class SynoPhotos(SynoBaseApi):
             "type": "unit",
         }
 
-        if item.passphrase is not None :
+        if item.passphrase is not None:
             params["passphrase"] = item.passphrase
 
         raw_data = await self._dsm.get(
@@ -184,8 +187,8 @@ class SynoPhotos(SynoBaseApi):
             "type": "unit",
         }
 
-        if item.passphrase is not None :
-             params["passphrase"] = item.passphrase
+        if item.passphrase is not None:
+            params["passphrase"] = item.passphrase
 
         return await self._dsm.generate_url(
             download_api,

--- a/src/synology_dsm/api/photos/__init__.py
+++ b/src/synology_dsm/api/photos/__init__.py
@@ -26,7 +26,11 @@ class SynoPhotos(SynoBaseApi):
         """Get a list of all albums."""
         albums: list[SynoPhotosAlbum] = []
         raw_data = await self._dsm.get(
-            self.BROWSE_ALBUMS_API_KEY, "list", {"offset": offset, "limit": limit}
+            self.BROWSE_ALBUMS_API_KEY, "list", {
+                "offset": offset,
+                "limit": limit,
+                "category": "normal_share_with_me"
+            }
         )
         if not isinstance(raw_data, dict) or (data := raw_data.get("data")) is None:
             return None
@@ -71,15 +75,20 @@ class SynoPhotos(SynoBaseApi):
         self, album: SynoPhotosAlbum, offset: int = 0, limit: int = 100
     ) -> list[SynoPhotosItem] | None:
         """Get a list of all items from given album."""
+        params = {
+            "offset": offset,
+            "limit": limit,
+            "additional": '["thumbnail"]',
+        }
+        if album.passphrase is not None:
+            params["passphrase"] = album.passphrase
+        else:
+            params["album_id"] = album.album_id
+
         raw_data = await self._dsm.get(
             self.BROWSE_ITEM_API_KEY,
             "list",
-            {
-                "album_id": album.album_id,
-                "offset": offset,
-                "limit": limit,
-                "additional": '["thumbnail"]',
-            },
+            params,
         )
         return self._raw_data_to_items(raw_data, album.passphrase)
 

--- a/src/synology_dsm/api/photos/model.py
+++ b/src/synology_dsm/api/photos/model.py
@@ -10,6 +10,7 @@ class SynoPhotosAlbum:
     album_id: int
     name: str
     item_count: int
+    passphrase: str
 
 
 @dataclass
@@ -23,3 +24,4 @@ class SynoPhotosItem:
     thumbnail_cache_key: str
     thumbnail_size: str
     is_shared: bool
+    passphrase: str

--- a/src/synology_dsm/api/photos/model.py
+++ b/src/synology_dsm/api/photos/model.py
@@ -1,5 +1,7 @@
 """Data models for Synology Photos Module."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 
@@ -10,7 +12,7 @@ class SynoPhotosAlbum:
     album_id: int
     name: str
     item_count: int
-    passphrase: str
+    passphrase: str | None
 
 
 @dataclass
@@ -24,4 +26,4 @@ class SynoPhotosItem:
     thumbnail_cache_key: str
     thumbnail_size: str
     is_shared: bool
-    passphrase: str
+    passphrase: str | None

--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -384,7 +384,7 @@ class SynologyDSM:
                 ]:
                     return dict(await response.json(content_type=content_type))
 
-                if content_type.startswith("image"):
+                if content_type == "application/octet-stream" or content_type.startswith("image"):
                     return await response.read()
 
                 return await response.text()

--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -384,7 +384,10 @@ class SynologyDSM:
                 ]:
                     return dict(await response.json(content_type=content_type))
 
-                if content_type == "application/octet-stream" or content_type.startswith("image"):
+                if (
+                    content_type == "application/octet-stream"
+                    or content_type.startswith("image")
+                ):
                     return await response.read()
 
                 return await response.text()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -71,6 +71,7 @@ from .api_data.dsm_7 import (
     DSM_7_DSM_INFORMATION,
     DSM_7_FOTO_ALBUMS,
     DSM_7_FOTO_ITEMS,
+    DSM_7_FOTO_ITEMS_SHARED_ALBUM,
     DSM_7_FOTO_ITEMS_SEARCHED,
     DSM_7_FOTO_SHARED_ITEMS,
 )
@@ -285,7 +286,10 @@ class SynologyDSMMock(SynologyDSM):
                 return DSM_7_FOTO_ALBUMS
 
             if SynoPhotos.BROWSE_ITEM_API_KEY in url:
-                return DSM_7_FOTO_ITEMS
+                if "album_id=3" in url:
+                    return DSM_7_FOTO_ITEMS_SHARED_ALBUM
+                else:
+                    return DSM_7_FOTO_ITEMS
 
             if SynoPhotos.SEARCH_API_KEY in url:
                 return DSM_7_FOTO_ITEMS_SEARCHED

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -71,8 +71,8 @@ from .api_data.dsm_7 import (
     DSM_7_DSM_INFORMATION,
     DSM_7_FOTO_ALBUMS,
     DSM_7_FOTO_ITEMS,
-    DSM_7_FOTO_ITEMS_SHARED_ALBUM,
     DSM_7_FOTO_ITEMS_SEARCHED,
+    DSM_7_FOTO_ITEMS_SHARED_ALBUM,
     DSM_7_FOTO_SHARED_ITEMS,
 )
 from .const import (

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -286,7 +286,7 @@ class SynologyDSMMock(SynologyDSM):
                 return DSM_7_FOTO_ALBUMS
 
             if SynoPhotos.BROWSE_ITEM_API_KEY in url:
-                if "album_id=3" in url:
+                if "passphrase" in url:
                     return DSM_7_FOTO_ITEMS_SHARED_ALBUM
                 else:
                     return DSM_7_FOTO_ITEMS

--- a/tests/api_data/dsm_7/__init__.py
+++ b/tests/api_data/dsm_7/__init__.py
@@ -1,4 +1,4 @@
-"""DSM 6 datas."""
+"""DSM 7 datas."""
 
 from .const_7_api_auth import (
     DSM_7_AUTH_LOGIN,

--- a/tests/api_data/dsm_7/__init__.py
+++ b/tests/api_data/dsm_7/__init__.py
@@ -14,6 +14,7 @@ from .dsm.const_7_dsm_info import DSM_7_DSM_INFORMATION
 from .photos.const_7_photo import (
     DSM_7_FOTO_ALBUMS,
     DSM_7_FOTO_ITEMS,
+    DSM_7_FOTO_ITEMS_SHARED_ALBUM,
     DSM_7_FOTO_ITEMS_SEARCHED,
     DSM_7_FOTO_SHARED_ITEMS,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "DSM_7_DSM_INFORMATION",
     "DSM_7_FOTO_ALBUMS",
     "DSM_7_FOTO_ITEMS",
+    "DSM_7_FOTO_ITEMS_SHARED_ALBUM",
     "DSM_7_FOTO_ITEMS_SEARCHED",
     "DSM_7_FOTO_SHARED_ITEMS",
 ]

--- a/tests/api_data/dsm_7/__init__.py
+++ b/tests/api_data/dsm_7/__init__.py
@@ -14,8 +14,8 @@ from .dsm.const_7_dsm_info import DSM_7_DSM_INFORMATION
 from .photos.const_7_photo import (
     DSM_7_FOTO_ALBUMS,
     DSM_7_FOTO_ITEMS,
-    DSM_7_FOTO_ITEMS_SHARED_ALBUM,
     DSM_7_FOTO_ITEMS_SEARCHED,
+    DSM_7_FOTO_ITEMS_SHARED_ALBUM,
     DSM_7_FOTO_SHARED_ITEMS,
 )
 

--- a/tests/api_data/dsm_7/core/const_7_core_external_usb.py
+++ b/tests/api_data/dsm_7/core/const_7_core_external_usb.py
@@ -1,4 +1,4 @@
-"""DSM 6 SYNO.Core.ExternalDevice.Storage.USB data."""
+"""DSM 7 SYNO.Core.ExternalDevice.Storage.USB data."""
 
 DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_NO_EXTERNAL_USB = {
     "data": {"devices": []},

--- a/tests/api_data/dsm_7/photos/const_7_photo.py
+++ b/tests/api_data/dsm_7/photos/const_7_photo.py
@@ -38,6 +38,25 @@ DSM_7_FOTO_ALBUMS = {
                 "type": "normal",
                 "version": 195694,
             },
+             {
+                "cant_migrate_condition": {},
+                "condition": {},
+                "create_time": 1718658534,
+                "end_time": 1719075481,
+                "freeze_album": False,
+                "id": 3,
+                "item_count": 1,
+                "name": "Album3",
+                "owner_user_id": 7,
+                "passphrase": "NiXlv1i2N",
+                "shared": False,
+                "sort_by": "default",
+                "sort_direction": "default",
+                "start_time": 1659724703,
+                "temporary_shared": False,
+                "type": "normal",
+                "version": 102886,
+            },
         ]
     },
     "success": True,
@@ -104,6 +123,34 @@ DSM_7_FOTO_ITEMS = {
                         "sm": "ready",
                         "cache_key": "29809_1668560967",
                         "unit_id": 29809,
+                    }
+                },
+            },
+        ]
+    },
+}
+
+DSM_7_FOTO_ITEMS_SHARED_ALBUM = {
+    "success": True,
+    "data": {
+        "list": [
+            {
+                "id": 29807,
+                "filename": "20221115_185645.jpg",
+                "filesize": 2644859,
+                "time": 1668538602,
+                "indexed_time": 1668564550862,
+                "owner_user_id": 7,
+                "folder_id": 597,
+                "type": "photo",
+                "additional": {
+                    "thumbnail": {
+                        "m": "ready",
+                        "xl": "ready",
+                        "preview": "broken",
+                        "sm": "ready",
+                        "cache_key": "29810_1668560967",
+                        "unit_id": 29807,
                     }
                 },
             },

--- a/tests/api_data/dsm_7/photos/const_7_photo.py
+++ b/tests/api_data/dsm_7/photos/const_7_photo.py
@@ -38,7 +38,7 @@ DSM_7_FOTO_ALBUMS = {
                 "type": "normal",
                 "version": 195694,
             },
-             {
+            {
                 "cant_migrate_condition": {},
                 "condition": {},
                 "create_time": 1718658534,

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -193,7 +193,7 @@ class TestSynologyDSM7:
         assert albums[2].album_id == 3
         assert albums[2].name == "Album3"
         assert albums[2].item_count == 1
-        assert albums[2].passphrase == 'NiXlv1i2N'
+        assert albums[2].passphrase == "NiXlv1i2N"
 
         items = await dsm_7.photos.get_items_from_album(albums[0])
         assert items
@@ -237,7 +237,7 @@ class TestSynologyDSM7:
         assert items[0].file_name == "20221115_185645.jpg"
         assert items[0].thumbnail_cache_key == "29810_1668560967"
         assert items[0].thumbnail_size == "xl"
-        assert items[0].passphrase == 'NiXlv1i2N'
+        assert items[0].passphrase == "NiXlv1i2N"
 
         thumb_url = await dsm_7.photos.get_item_thumbnail_url(items[0])
         assert thumb_url

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -179,13 +179,21 @@ class TestSynologyDSM7:
         albums = await dsm_7.photos.get_albums()
 
         assert albums
-        assert len(albums) == 2
+        assert len(albums) == 3
         assert albums[0].album_id == 4
         assert albums[0].name == "Album1"
         assert albums[0].item_count == 3
+        assert albums[0].passphrase is None
+
         assert albums[1].album_id == 1
         assert albums[1].name == "Album2"
         assert albums[1].item_count == 1
+        assert albums[1].passphrase is None
+
+        assert albums[2].album_id == 3
+        assert albums[2].name == "Album3"
+        assert albums[2].item_count == 1
+        assert albums[2].passphrase == 'NiXlv1i2N'
 
         items = await dsm_7.photos.get_items_from_album(albums[0])
         assert items
@@ -193,12 +201,17 @@ class TestSynologyDSM7:
         assert items[0].file_name == "20221115_185642.jpg"
         assert items[0].thumbnail_cache_key == "29807_1668560967"
         assert items[0].thumbnail_size == "xl"
+        assert items[0].passphrase is None
+
         assert items[1].file_name == "20221115_185643.jpg"
         assert items[1].thumbnail_cache_key == "29808_1668560967"
         assert items[1].thumbnail_size == "m"
+        assert items[1].passphrase is None
+
         assert items[2].file_name == "20221115_185644.jpg"
         assert items[2].thumbnail_cache_key == "29809_1668560967"
         assert items[2].thumbnail_size == "sm"
+        assert items[2].passphrase is None
 
         thumb_url = await dsm_7.photos.get_item_thumbnail_url(items[0])
         assert thumb_url
@@ -215,6 +228,23 @@ class TestSynologyDSM7:
             "https://nas.mywebsite.me:443/webapi/entry.cgi?"
             "id=29808&cache_key=29808_1668560967&size=m&type=unit"
             "&api=SYNO.FotoTeam.Thumbnail&version=2&method=get"
+            "&_sid=session_id&SynoToken=Sy%C3%B10_T0k%E2%82%AC%C3%B1"
+        )
+
+        items = await dsm_7.photos.get_items_from_album(albums[2])
+        assert items
+        assert len(items) == 1
+        assert items[0].file_name == "20221115_185645.jpg"
+        assert items[0].thumbnail_cache_key == "29810_1668560967"
+        assert items[0].thumbnail_size == "xl"
+        assert items[0].passphrase == 'NiXlv1i2N'
+
+        thumb_url = await dsm_7.photos.get_item_thumbnail_url(items[0])
+        assert thumb_url
+        assert thumb_url == (
+            "https://nas.mywebsite.me:443/webapi/entry.cgi?"
+            "id=29807&cache_key=29810_1668560967&size=xl&type=unit"
+            "&passphrase=NiXlv1i2N&api=SYNO.Foto.Thumbnail&version=2&method=get"
             "&_sid=session_id&SynoToken=Sy%C3%B10_T0k%E2%82%AC%C3%B1"
         )
 


### PR DESCRIPTION
**Context :** 
Shared album have a `passphrase` field that is used in the public sharing link. It is also required by the download and thumbnail api methods.
See https://github.com/home-assistant/core/issues/120817 for more detail.

This PR adds passphrase handling, fixing downloading photos from different users in shared albums.
Additionally, it addresses a problem I encountered with HEIC photos that return an `application/octet-stream` content type.

Fixes #299