### PR TITLE
Fix tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -129,7 +129,7 @@ API_SWITCHER = {
 
 
 VALID_HOST = "nas.mywebsite.me"
-VALID_PORT = "443"
+VALID_PORT = "5001"
 VALID_HTTPS = True
 VALID_VERIFY_SSL = True
 VALID_USER = "valid_user"

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -243,7 +243,7 @@ class TestSynologyDSM7:
         thumb_url = await dsm_7.photos.get_item_thumbnail_url(items[0])
         assert thumb_url
         assert thumb_url == (
-            "https://nas.mywebsite.me:443/webapi/entry.cgi?"
+            f"https://{VALID_HOST}:{VALID_PORT}/webapi/entry.cgi?"
             "id=29807&cache_key=29807_1668560967&size=xl&type=unit"
             "&api=SYNO.Foto.Thumbnail&version=2&method=get"
             "&_sid=session_id&SynoToken=Sy%C3%B10_T0k%E2%82%AC%C3%B1"
@@ -252,7 +252,7 @@ class TestSynologyDSM7:
         thumb_url = await dsm_7.photos.get_item_thumbnail_url(items[1])
         assert thumb_url
         assert thumb_url == (
-            "https://nas.mywebsite.me:443/webapi/entry.cgi?"
+            f"https://{VALID_HOST}:{VALID_PORT}/webapi/entry.cgi?"
             "id=29808&cache_key=29808_1668560967&size=m&type=unit"
             "&api=SYNO.FotoTeam.Thumbnail&version=2&method=get"
             "&_sid=session_id&SynoToken=Sy%C3%B10_T0k%E2%82%AC%C3%B1"
@@ -269,7 +269,7 @@ class TestSynologyDSM7:
         thumb_url = await dsm_7.photos.get_item_thumbnail_url(items[0])
         assert thumb_url
         assert thumb_url == (
-            "https://nas.mywebsite.me:443/webapi/entry.cgi?"
+            f"https://{VALID_HOST}:{VALID_PORT}/webapi/entry.cgi?"
             "id=29807&cache_key=29810_1668560967&size=xl&type=unit"
             "&passphrase=NiXlv1i2N&api=SYNO.Foto.Thumbnail&version=2&method=get"
             "&_sid=session_id&SynoToken=Sy%C3%B10_T0k%E2%82%AC%C3%B1"


### PR DESCRIPTION
With yarl 1.9.5 protocol default ports will not be added to the url anymore (_which is correct_), so we use now another https port