### PR TITLE
Reconnect after DSM API Error 105 Insufficient user privilege

### DIFF
--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -343,6 +343,12 @@ class SynologyDSM:
                 self._session_id = None
                 self._syno_token = None
                 return await self._request(request_method, api, method, params, False)
+
+            if response["error"]["code"] == 105:
+                # DSM 5.2 seems to lose login when user has insufficient user privileges, login
+                # again
+                await self.login()
+
             raise SynologyDSMAPIErrorException(
                 api, response["error"]["code"], response["error"].get("errors")
             )


### PR DESCRIPTION
This fixes https://github.com/home-assistant/core/issues/138607

This fix is might be a bit to generic, maybe there needs to be a check if the connection is actually lost before reconnection