### PR TITLE
Clear external USB data before fetching from DSM

### DIFF
--- a/src/synology_dsm/api/core/external_usb.py
+++ b/src/synology_dsm/api/core/external_usb.py
@@ -47,7 +47,7 @@ class SynoCoreExternalUSB(SynoBaseApi["dict[str, SynoCoreExternalUSBDevice]"]):
 
     async def update(self) -> None:
         """Updates external USB storage device data."""
-        self._data = {}
+        self._data: dict[str, SynoCoreExternalUSBDevice] = {}
         raw_data = await self._dsm.post(self.API_KEY, "list", data=self.REQUEST_DATA)
         if isinstance(raw_data, dict) and (data := raw_data.get("data")) is not None:
             for device in data["devices"]:

--- a/src/synology_dsm/api/core/external_usb.py
+++ b/src/synology_dsm/api/core/external_usb.py
@@ -47,6 +47,7 @@ class SynoCoreExternalUSB(SynoBaseApi["dict[str, SynoCoreExternalUSBDevice]"]):
 
     async def update(self) -> None:
         """Updates external USB storage device data."""
+        self._data = {}
         raw_data = await self._dsm.post(self.API_KEY, "list", data=self.REQUEST_DATA)
         if isinstance(raw_data, dict) and (data := raw_data.get("data")) is not None:
             for device in data["devices"]:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -182,7 +182,7 @@ class SynologyDSMMock(SynologyDSM):
         self.disks_redundancy = "RAID"  # RAID or SHR[number][_EXPANSION]
         self.error = False
         self.with_surveillance = False
-        self._external_usb_update_call_count = 0
+        self.usb_device_connected = True
 
     async def _execute_request(
         self, method, url, params, raw_response_content, **kwargs
@@ -254,10 +254,9 @@ class SynologyDSMMock(SynologyDSM):
                 return ERROR_INSUFFICIENT_USER_PRIVILEGE
 
             if SynoCoreExternalUSB.API_KEY in url:
-                self._external_usb_update_call_count += 1
-                if self._external_usb_update_call_count == 1:
+                if self.usb_device_connected:
                     return DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_EXTERNAL_USB
-                if self._external_usb_update_call_count == 2:
+                if not self.usb_device_connected:
                     return DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_NO_EXTERNAL_USB
 
             if SynoCoreSecurity.API_KEY in url:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -69,6 +69,7 @@ from .api_data.dsm_7 import (
     DSM_7_AUTH_LOGIN_2SA,
     DSM_7_AUTH_LOGIN_2SA_OTP,
     DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_EXTERNAL_USB,
+    DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_NO_EXTERNAL_USB,
     DSM_7_CORE_UPGRADE_TRUE,
     DSM_7_DSM_INFORMATION,
     DSM_7_FILE_STATION_FILES,
@@ -181,6 +182,7 @@ class SynologyDSMMock(SynologyDSM):
         self.disks_redundancy = "RAID"  # RAID or SHR[number][_EXPANSION]
         self.error = False
         self.with_surveillance = False
+        self._external_usb_update_call_count = 0
 
     async def _execute_request(
         self, method, url, params, raw_response_content, **kwargs
@@ -252,7 +254,11 @@ class SynologyDSMMock(SynologyDSM):
                 return ERROR_INSUFFICIENT_USER_PRIVILEGE
 
             if SynoCoreExternalUSB.API_KEY in url:
-                return DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_EXTERNAL_USB
+                self._external_usb_update_call_count += 1
+                if self._external_usb_update_call_count == 1:
+                    return DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_EXTERNAL_USB
+                if self._external_usb_update_call_count == 2:
+                    return DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_NO_EXTERNAL_USB
 
             if SynoCoreSecurity.API_KEY in url:
                 if self.error:

--- a/tests/api_data/dsm_7/__init__.py
+++ b/tests/api_data/dsm_7/__init__.py
@@ -8,6 +8,7 @@ from .const_7_api_auth import (
 from .const_7_api_info import DSM_7_API_INFO
 from .core.const_7_core_external_usb import (
     DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_EXTERNAL_USB,
+    DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_NO_EXTERNAL_USB,
 )
 from .core.const_7_core_upgrade import DSM_7_CORE_UPGRADE_FALSE, DSM_7_CORE_UPGRADE_TRUE
 from .dsm.const_7_dsm_info import DSM_7_DSM_INFORMATION
@@ -30,6 +31,7 @@ __all__ = [
     "DSM_7_AUTH_LOGIN_2SA_OTP",
     "DSM_7_API_INFO",
     "DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_EXTERNAL_USB",
+    "DSM_7_CORE_EXTERNAL_USB_DS1821_PLUS_NO_EXTERNAL_USB",
     "DSM_7_CORE_UPGRADE_FALSE",
     "DSM_7_CORE_UPGRADE_TRUE",
     "DSM_7_DSM_INFORMATION",

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -178,6 +178,7 @@ class TestSynologyDSM7:
         assert partition.partition_percentage_used is None
 
         # Verify devices is cleared before update
+        dsm_7.usb_device_connected = False
         await dsm_7.external_usb.update()
         devices = dsm_7.external_usb.get_devices
         assert len(devices) == 0

--- a/tests/test_synology_dsm_7.py
+++ b/tests/test_synology_dsm_7.py
@@ -177,6 +177,11 @@ class TestSynologyDSM7:
         assert partition.partition_size_used(False) is None
         assert partition.partition_percentage_used is None
 
+        # Verify devices is cleared before update
+        await dsm_7.external_usb.update()
+        devices = dsm_7.external_usb.get_devices
+        assert len(devices) == 0
+
     @pytest.mark.asyncio
     async def test_login_2sa_new_session(self):
         """Test login with 2SA and a new session with granted device."""


### PR DESCRIPTION
This should resolve an issue where an external USB drive has been ejected via DSM but the data for the drive is still in `self._data`.

Related to https://github.com/home-assistant/core/issues/144575