### PR TITLE
Fix core.hardware to match DSM 6.2 devices

### DIFF
--- a/src/synology_dsm/api/core/hardware.py
+++ b/src/synology_dsm/api/core/hardware.py
@@ -57,11 +57,14 @@ class SynoCoreHardware(SynoBaseApi[HardwareDataType]):
             and (data := raw_data_fan_speed.get("data")) is not None
         ):
             fan_speed = HardwareFan(
-                all_disk_temp_fail=data["all_disk_temp_fail"] == "yes",
+                all_disk_temp_fail=data.get("all_disk_temp_fail", "no") == "yes",
                 cool_fan=data["cool_fan"] == "yes",
                 dual_fan_speed=FanSpeed(data["dual_fan_speed"]),
                 fan_support_adjust_by_ext_nic=(
-                    data.get("fan_support_adjust_by_ext_nic", "no") == "yes"
+                    data.get(
+                        "fan_support_adjust_by_ext_nic", data.get("has_ext_nic", "no")
+                    )
+                    == "yes"
                 ),
                 fan_type=data["fan_type"],
             )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -40,6 +40,7 @@ from .api_data.dsm_6 import (
     DSM_6_AUTH_LOGIN,
     DSM_6_AUTH_LOGIN_2SA,
     DSM_6_AUTH_LOGIN_2SA_OTP,
+    DSM_6_CORE_HARDWARE_FANSPEED,
     DSM_6_CORE_SECURITY,
     DSM_6_CORE_SECURITY_UPDATE_OUTOFDATE,
     DSM_6_CORE_SHARE,
@@ -111,6 +112,7 @@ API_SWITCHER = {
         "AUTH_LOGIN_2SA_OTP": DSM_6_AUTH_LOGIN_2SA_OTP,
         "DSM_INFORMATION": DSM_6_DSM_INFORMATION,
         "DSM_NETWORK": DSM_6_DSM_NETWORK_2LAN_1PPPOE,
+        "CORE_HARDWARE": DSM_6_CORE_HARDWARE_FANSPEED,
         "CORE_SECURITY": DSM_6_CORE_SECURITY,
         "CORE_SHARE": DSM_6_CORE_SHARE,
         "CORE_SYSTEM": DSM_6_CORE_SYSTEM_DS918_PLUS,
@@ -128,6 +130,7 @@ API_SWITCHER = {
         "AUTH_LOGIN": DSM_7_AUTH_LOGIN,
         "AUTH_LOGIN_2SA": DSM_7_AUTH_LOGIN_2SA,
         "AUTH_LOGIN_2SA_OTP": DSM_7_AUTH_LOGIN_2SA_OTP,
+        "CORE_HARDWARE": DSM_7_CORE_HARDWARE_FANSPEED,
         "CORE_UPGRADE": DSM_7_CORE_UPGRADE_TRUE,
         "DSM_INFORMATION": DSM_7_DSM_INFORMATION,
         "FOTO_ALBUMS": DSM_7_FOTO_ALBUMS,
@@ -265,7 +268,7 @@ class SynologyDSMMock(SynologyDSM):
             if SynoCoreHardware.API_KEY_FANSPEED in url:
                 if SynoCoreHardware.API_KEY_FANSPEED in self.no_data_responses:
                     return {"success": True}
-                return DSM_7_CORE_HARDWARE_FANSPEED
+                return API_SWITCHER[self.dsm_version]["CORE_HARDWARE"]
 
             if SynoCoreSecurity.API_KEY in url:
                 if self.error:

--- a/tests/api_data/dsm_6/__init__.py
+++ b/tests/api_data/dsm_6/__init__.py
@@ -6,6 +6,7 @@ from .const_6_api_auth import (
     DSM_6_AUTH_LOGIN_2SA_OTP,
 )
 from .const_6_api_info import DSM_6_API_INFO
+from .core.const_6_core_hardware import DSM_6_CORE_HARDWARE_FANSPEED
 from .core.const_6_core_security import (
     DSM_6_CORE_SECURITY,
     DSM_6_CORE_SECURITY_UPDATE_OUTOFDATE,
@@ -57,6 +58,7 @@ __all__ = [
     "DSM_6_AUTH_LOGIN_2SA",
     "DSM_6_AUTH_LOGIN_2SA_OTP",
     "DSM_6_API_INFO",
+    "DSM_6_CORE_HARDWARE_FANSPEED",
     "DSM_6_CORE_SECURITY",
     "DSM_6_CORE_SECURITY_UPDATE_OUTOFDATE",
     "DSM_6_CORE_SHARE",

--- a/tests/api_data/dsm_6/core/const_6_core_hardware.py
+++ b/tests/api_data/dsm_6/core/const_6_core_hardware.py
@@ -3,7 +3,7 @@
 DSM_6_CORE_HARDWARE_FANSPEED = {
     "data": {
         "cool_fan": "yes",
-        "dual_fan_speed": "quietfan",
+        "dual_fan_speed": "coolfan",
         "has_ext_nic": "no",
         "fan_type": 1,
     },

--- a/tests/api_data/dsm_6/core/const_6_core_hardware.py
+++ b/tests/api_data/dsm_6/core/const_6_core_hardware.py
@@ -1,0 +1,11 @@
+"""DSM 6 SYNO.Core.Hardware data."""
+
+DSM_6_CORE_HARDWARE_FANSPEED = {
+    "data": {
+        "cool_fan": "yes",
+        "dual_fan_speed": "quietfan",
+        "has_ext_nic": "no",
+        "fan_type": 1,
+    },
+    "success": True,
+}

--- a/tests/test_synology_dsm_6.py
+++ b/tests/test_synology_dsm_6.py
@@ -528,11 +528,11 @@ class TestSynologyDSM6:
         assert await dsm_6.login()
         assert dsm_6.hardware
         await dsm_6.hardware.update()
-        assert dsm_6.hardware.fan_speed == FanSpeed.QUIET
+        assert dsm_6.hardware.fan_speed == FanSpeed.COOL
         assert dsm_6.hardware.supported_fan_speeds == [FanSpeed.COOL]
         data = dsm_6.hardware.data
         assert data["fan_speed"]["all_disk_temp_fail"] is False
         assert data["fan_speed"]["cool_fan"] is True
-        assert data["fan_speed"]["dual_fan_speed"] == FanSpeed.QUIET
+        assert data["fan_speed"]["dual_fan_speed"] == FanSpeed.COOL
         assert data["fan_speed"]["fan_support_adjust_by_ext_nic"] is False
         assert data["fan_speed"]["fan_type"] == 1

--- a/tests/test_synology_dsm_6.py
+++ b/tests/test_synology_dsm_6.py
@@ -3,6 +3,7 @@
 # pylint: disable=protected-access
 import pytest
 
+from synology_dsm.api.core.hardware import FanSpeed
 from synology_dsm.const import API_AUTH
 from synology_dsm.exceptions import SynologyDSMLogin2SARequiredException
 
@@ -520,3 +521,18 @@ class TestSynologyDSM6:
         assert await dsm_6.surveillance_station.get_home_mode_status()
         assert await dsm_6.surveillance_station.set_home_mode(False)
         assert await dsm_6.surveillance_station.set_home_mode(True)
+
+    @pytest.mark.asyncio
+    async def test_hardware(self, dsm_6):
+        """Test hardware."""
+        assert await dsm_6.login()
+        assert dsm_6.hardware
+        await dsm_6.hardware.update()
+        assert dsm_6.hardware.fan_speed == FanSpeed.QUIET
+        assert dsm_6.hardware.supported_fan_speeds == [FanSpeed.COOL]
+        data = dsm_6.hardware.data
+        assert data["fan_speed"]["all_disk_temp_fail"] is False
+        assert data["fan_speed"]["cool_fan"] is True
+        assert data["fan_speed"]["dual_fan_speed"] == FanSpeed.QUIET
+        assert data["fan_speed"]["fan_support_adjust_by_ext_nic"] is False
+        assert data["fan_speed"]["fan_type"] == 1


### PR DESCRIPTION
ref.: https://github.com/home-assistant/core/issues/175763